### PR TITLE
frontend-maven-plugin now runs karma rather than npm test for test st…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "EnDDaT User Interface",
   "main": "dataDiscovery.jsp",
   "scripts": {
-    "test": "node/node node_modules/karma/bin/karma start src/tests/js/karma.conf.js --single-run --browsers Firefox --reporters dots,coverage"
+    "test": "node_modules/karma/bin/karma start src/tests/js/karma.conf.js --no-single-run --browsers \"\"  --reporters progress"
   },
   "repository": {
     "type": "git",

--- a/pom.xml
+++ b/pom.xml
@@ -209,11 +209,11 @@
 					<execution>
 						<id>javascript tests</id>
 						<goals>
-							<goal>npm</goal>
+							<goal>karma</goal>
 						</goals>
 						<phase>test</phase>
 						<configuration>
-							<arguments>test</arguments>
+							<karmaConfPath>src/tests/js/karma.conf.js</karmaConfPath>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/tests/js/karma.conf.js
+++ b/src/tests/js/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-        'src/tests/js/test-main.js',     
+        'src/tests/js/test-main.js',
       {pattern: 'src/main/webapp/js/bower_components/Squire.js/src/Squire.js', included: false},
       {pattern: 'src/main/webapp/js/bower_components/sinon/lib/sinon.js', included: false},
       {pattern: 'src/main/webapp/js/bower_components/jquery/dist/jquery.js', included: false},
@@ -51,7 +51,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+    reporters: ['dots,coverage'],
 
 
     coverageReporter: {
@@ -81,12 +81,12 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: [],
+    browsers: ['Firefox'],
 
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
+    singleRun: true,
 
     // Concurrency level
     // how many browser should be started simultaneous


### PR DESCRIPTION
…ep. Updated karma.conf.js to include all flags needed in the CI and build environment. To make things easier on a developer modified the test script to run without a browser, with single-run disabled, and reporters progress. This assumes that npm is installed on the caller's environment. This is merely a convience for the developer.