### PR TITLE
Enddat 139

### DIFF
--- a/src/main/webapp/dataDiscovery.jsp
+++ b/src/main/webapp/dataDiscovery.jsp
@@ -5,7 +5,6 @@
 		<%@include file="/WEB-INF/jsp/head.jsp"%>
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<link rel="stylesheet" type="text/css" href="<%=baseUrl%>bower_components/select2/dist/css/select2.min.css" />
-		<link rel="stylesheet" type="text/css" href="<%=baseUrl%>bower_components/select2-bootstrap-theme/dist/select2-bootstrap.min.css" />
 		<link rel="stylesheet" type="text/css" href="<%=baseUrl%>bower_components/leaflet/dist/leaflet.css" />
 		<link rel="stylesheet" type="text/css" href="css/custom.css" />
 	</head>

--- a/src/main/webapp/js/controller/AppRouter.js
+++ b/src/main/webapp/js/controller/AppRouter.js
@@ -50,24 +50,26 @@ define([
 		},
 
 		specifyProjectLocationState: function () {
+			this.workflowState.set('step', this.workflowState.PROJ_LOC_STEP);
 			this.createView(DataDiscoveryView, {
 				model : this.workflowState
 			}).render();
-			this.workflowState.set('step', this.workflowState.PROJ_LOC_STEP);
 		},
 
 		chooseDataState : function(lat, lng, radius, startDate, endDate, datasets) {
-			this.createView(DataDiscoveryView, {
-				model : this.workflowState
-			}).render();
+			this.workflowState.initializeDatasetCollections();
 			this.workflowState.set({
 				'location' : {latitude : lat, longitude : lng},
 				'radius' : radius,
 				'startDate' : startDate,
-				'endDate' : endDate,
-				'datasets' : datasets ? datasets.split('/') : []
+				'endDate' : endDate
 			});
 			this.workflowState.set('step', this.workflowState.CHOOSE_DATA_STEP);
+			this.createView(DataDiscoveryView, {
+				model : this.workflowState
+			}).render();
+			this.workflowState.set('datasets', datasets ? datasets.split('/') : []);
+
 		}
 	});
 

--- a/src/main/webapp/js/hb_templates/choose.hbs
+++ b/src/main/webapp/js/hb_templates/choose.hbs
@@ -5,6 +5,9 @@
 	</div>
 	<div class="form-group">
 		<label for="datasets-select">Datasets</label>
-		<select id="datasets-select" class="form-control" multiple></select>
+		<select id="datasets-select" class="form-control" multiple>
+			<option value="NWIS">USGS Time Series (NWIS)</option>
+			<option value="PRECIP">1 Hr National Precipitation Grid Points</option>
+		</select>
 	</div>
 </div>

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -138,13 +138,8 @@ define([
 				case this.CHOOSE_DATA_STEP:
 					if (previousStep === this.PROJ_LOC_STEP) {
 						this.initializeDatasetCollections();
-						this.set({
-							radius : this.DEFAULT_CHOOSE_DATA_RADIUS,
-							datasets : this.DEFAULT_CHOSEN_DATASETS
-						}, {
-							silent: true
-						});
-						this.fetchDatasets(this.DEFAULT_CHOSEN_DATASETS);
+						this.set('datasets', this.DEFAULT_CHOSEN_DATASETS, {silent: true});
+						this.set('radius', this.DEFAULT_CHOOSE_DATA_RADIUS);
 					}
 					break;
 			}

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -13,6 +13,7 @@ define([
 	var model = Backbone.Model.extend({
 		NWIS_DATASET : 'NWIS',
 		PRECIP_DATASET : 'PRECIP',
+		ALL_DATASETS : ['NWIS', 'PRECIP'],
 
 		PROJ_LOC_STEP : 'specifyProjectLocation',
 		CHOOSE_DATA_STEP : 'chooseData',
@@ -30,7 +31,7 @@ define([
 		initialize : function(attributes, options) {
 			Backbone.Model.prototype.initialize.apply(this, arguments);
 
-			this.on('change:step', this.updateModelState);
+			this.on('change:step', this.updateModelState, this);
 		},
 
 		/*
@@ -51,10 +52,8 @@ define([
 					[this.PRECIP_DATASET, new PrecipitationCollection()]
 				]);
 				this.set('datasetCollections', datasetCollections);
-
-				// Set up event listeners to update the dataset models
-				this.on('change:location', this.updateDatasetCollections, this);
 				this.on('change:radius', this.updateDatasetCollections, this);
+				this.on('change:location', this.updateDatasetCollections, this);
 				this.on('change:datasets', this.updateDatasetCollections, this);
 			}
 		},
@@ -63,7 +62,7 @@ define([
 			return (this.has('location') &&
 				((this.attributes.location.latitude) ? true : false) &&
 				((this.attributes.location.longitude) ? true : false));
-				
+
 		},
 
 		/*
@@ -92,72 +91,100 @@ define([
 		  */
 		updateDatasetCollections : function() {
 			var self = this;
+			var previousAttributes = this.previousAttributes();
 
 			var boundingBox = this.getBoundingBox();
 			var chosenDatasets = this.has('datasets') ? this.get('datasets') : [];
-			var datasetCollections = this.get('datasetCollections');
-			var fetchDonePromises = [];
-			var fetchErrors = [];
+			var previousChosenDatasets = _.has(previousAttributes, 'datasets') ? previousAttributes.datasets : [];
 
-			var updateDataset = function(datasetCollection, datasetKind) {
-				if (_.contains(chosenDatasets, datasetKind)) {
-					var donePromise = $.Deferred();
-					fetchDonePromises.push(donePromise);
+			var datasetsToFetch = {};
+			var datasetsToClear = {};
 
-					datasetCollection.fetch(boundingBox)
-						.fail(function() {
-							fetchErrors.push(datasetKind);
-						})
-						.always(function() {
-							donePromise.resolve();
-						});
+			if (this.hasChanged('radius') || this.hasChanged('location')) {
+				//Need to fetch/clear all dataset collections
+				if (boundingBox) {
+					datasetsToFetch = chosenDatasets;
+					datasetsToClear = _.difference(this.ALL_DATASETS, chosenDatasets);
 				}
 				else {
-					datasetCollection.reset();
+					datasetsToClear = this.ALL_DATASETS;
 				}
-			};
-
-			if (boundingBox && (chosenDatasets.length > 0)) {
-				this.trigger('dataset:updateStart');
-				_.each(datasetCollections, updateDataset);
-				$.when.apply(this, fetchDonePromises).done(function() {
-					self.trigger('dataset:updateFinished', fetchErrors);
-				});
 			}
 			else {
-				// Clear the dataset collections if bounding box invalid or no chosen datasets
-				_.each(datasetCollections, function(datasetCollection) {
-					datasetCollection.reset();
+				//Update only datasets that have been added or removed from the chosen datasets
+				datasetsToFetch = _.difference(chosenDatasets, previousChosenDatasets);
+				datasetsToClear =  _.difference(previousChosenDatasets, chosenDatasets);
+			}
+
+			this.fetchDatasets(datasetsToFetch);
+			this.clearDatasets(datasetsToClear);
+		},
+
+		updateModelState : function() {
+			var previousStep = this.previous('step');
+
+			switch(this.get('step')) {
+				case this.PROJ_LOC_STEP:
+					if (this.has('datasetCollections')) {
+						_.each(this.get('datasetCollections'), function(collection) {
+							collection.reset();
+						});
+					};
+					this.unset('location', {silent : true});
+					this.unset('radius', {silent : true});
+					this.unset('datasets', {silent : true});
+					break;
+
+				case this.CHOOSE_DATA_STEP:
+					if (previousStep === this.PROJ_LOC_STEP) {
+						this.initializeDatasetCollections();
+						this.set({
+							radius : this.DEFAULT_CHOOSE_DATA_RADIUS,
+							datasets : this.DEFAULT_CHOSEN_DATASETS
+						}, {
+							silent: true
+						});
+						this.fetchDatasets(this.DEFAULT_CHOSEN_DATASETS);
+					}
+					break;
+			}
+		},
+
+		fetchDatasets : function(datasetKinds) {
+			var self = this;
+			var datasetsToFetch = _.pick(this.get('datasetCollections'), datasetKinds);
+			var boundingBox = this.getBoundingBox();
+			var fetchDonePromises = [];
+
+			var fetchDataset = function(datasetCollection, datasetKind) {
+				var donePromise = $.Deferred();
+				datasetCollection.fetch(boundingBox)
+					.done(function() {
+						donePromise.resolve();
+					})
+					.fail(function() {
+						donePromise.resolve(datasetKind);
+					});
+				return donePromise;
+			};
+
+			if (!_.isEmpty(datasetsToFetch) && (boundingBox)) {
+				this.trigger('dataset:updateStart');
+				fetchDonePromises = _.map(datasetsToFetch, fetchDataset);
+				$.when.apply(this, fetchDonePromises).done(function() {
+					var datasetKindErrors = _.filter(arguments, function(arg) {
+						return (arg) ? true : false;
+					});
+					self.trigger('dataset:updateFinished', datasetKindErrors);
 				});
 			}
 		},
 
-		updateModelState : function(model, newStep) {
-			var previousStep = model.previous('step');
-
-			switch(newStep) {
-				case model.PROJ_LOC_STEP:
-					if (model.has('datasetCollections')) {
-						_.each(model.get('datasetCollections'), function(collection) {
-							collection.reset();
-						});
-					};
-					model.unset('location');
-					model.unset('radius');
-					model.unset('datasets');
-					break;
-
-				case model.CHOOSE_DATA_STEP:
-					if (previousStep === model.PROJ_LOC_STEP) {
-						model.set({
-							radius : model.DEFAULT_CHOOSE_DATA_RADIUS,
-							datasets : model.DEFAULT_CHOSEN_DATASETS
-						});
-					}
-					model.initializeDatasetCollections();
-					model.updateDatasetCollections(model, model.get('datasetCollections'));
-					break;
-			}
+		clearDatasets : function(datasetKinds) {
+			var datasetsToClear = _.pick(this.get('datasetCollections'), datasetKinds);
+			_.each(datasetsToClear, function(datasetCollection) {
+				datasetCollection.reset();
+			});
 		}
 	});
 

--- a/src/main/webapp/js/views/ChooseView.js
+++ b/src/main/webapp/js/views/ChooseView.js
@@ -34,17 +34,12 @@ define([
 
 
 		render : function() {
-			var datasetOptions = _.map(this.model.ALL_DATASETS, function(kind) {
-				return {
-					id : kind,
-					text : kind
-				};
-			});
 			BaseCollapsiblePanelView.prototype.render.apply(this, arguments);
 			this.stickit();
 
 			this.$('#datasets-select').select2({
-				data : datasetOptions
+				allowClear : true,
+				theme : 'bootstrap'
 			});
 			this.updateDatasets();
 

--- a/src/main/webapp/less/custom.less
+++ b/src/main/webapp/less/custom.less
@@ -1,4 +1,5 @@
 @import "../bower_components/bootstrap/less/bootstrap.less";
+@import "../bower_components/select2-bootstrap-theme/src/select2-bootstrap.less";
 @import "../bower_components/font-awesome/less/font-awesome.less";
 
 @icon-font-path : "../bower/bootstrap/fonts/";

--- a/src/test/js/models/WorkflowStateModelSpec.js
+++ b/src/test/js/models/WorkflowStateModelSpec.js
@@ -8,7 +8,7 @@ define([
 	'utils/geoSpatialUtils'
 ], function(Squire, $, Backbone, geoSpatialUtils) {
 
-	describe('models/WorkflowStateModel', function() {
+	fdescribe('models/WorkflowStateModel', function() {
 		var injector;
 		var WorkflowStateModel, testModel;
 
@@ -227,27 +227,22 @@ define([
 			});
 
 			it('Expects that if the step changes to CHOOSE_DATA_STEP and the previous step was PROJ_LOC_STEP that the default radius and chosen datasets are set', function() {
-				testModel.set({
-					step : testModel.PROJ_LOC_STEP,
-					location : {latitude : '43.0', longitude : '-100.0'}
-				});
+				testModel.set('step', testModel.PROJ_LOC_STEP);
+				testModel.set('location', {latitude : '43.0', longitude : '-100.0'});
 				testModel.set('step', testModel.CHOOSE_DATA_STEP);
 
 				expect(testModel.get('radius')).toEqual(testModel.DEFAULT_CHOOSE_DATA_RADIUS);
 				expect(testModel.get('datasets')).toEqual(testModel.DEFAULT_CHOSEN_DATASETS);
 			});
 
-			it('Expects that if the step changes to CHOOSE_DATA_STEP, the chosen datasets are fetched', function() {
-				testModel.set({
-					location : {latitude : '43.0', longitude : '-100.0'},
-					radius : '6',
-					datasets : [testModel.NWIS_DATASET, testModel.PRECIP_DATASET]
-				});
+			it('Expects that if the step changes to CHOOSE_DATA_STEP and the previous step was PROJ_LOC_STEP, the chosen datasets are fetched', function() {
+				testModel.set('step', testModel.PROJ_LOC_STEP);
+				testModel.set('location', {latitude : '43.0', longitude : '-100.0'});
 				fetchPrecipSpy.calls.reset();
 				fetchSiteSpy.calls.reset();
 				testModel.set('step', testModel.CHOOSE_DATA_STEP);
 
-				expect(fetchPrecipSpy).toHaveBeenCalled();
+				expect(fetchPrecipSpy).not.toHaveBeenCalled();
 				expect(fetchSiteSpy).toHaveBeenCalled();
 			});
 		});

--- a/src/test/js/models/WorkflowStateModelSpec.js
+++ b/src/test/js/models/WorkflowStateModelSpec.js
@@ -8,7 +8,7 @@ define([
 	'utils/geoSpatialUtils'
 ], function(Squire, $, Backbone, geoSpatialUtils) {
 
-	fdescribe('models/WorkflowStateModel', function() {
+	describe('models/WorkflowStateModel', function() {
 		var injector;
 		var WorkflowStateModel, testModel;
 

--- a/src/test/js/views/ChooseViewSpec.js
+++ b/src/test/js/views/ChooseViewSpec.js
@@ -65,9 +65,18 @@ define([
 				expect(testModel.get('radius')).toEqual('5');
 			});
 
+			// Have to call the select2 event handlers directly
 			it('Expects that changing the datasets updates the model\'s datasets property', function() {
-				$datasets.select2({data : [{'id':'NWIS', 'selected': 'selected'}]}).trigger('change');
+				var ev = {
+					params : {
+						data : {id : 'NWIS'}
+					}
+				};
+				testView.selectDataset(ev);
 				expect(testModel.get('datasets')).toEqual(['NWIS']);
+
+				testView.resetDataset(ev);
+				expect(testModel.get('datasets')).toEqual([]);
 			});
 		});
 

--- a/src/test/js/views/MapViewSpec.js
+++ b/src/test/js/views/MapViewSpec.js
@@ -51,6 +51,7 @@ define([
 
 			testModel = new WorkflowStateModel();
 			testModel.set('step', testModel.CHOOSE_DATA_STEP);
+			testModel.initializeDatasetCollections();
 			testSiteCollection = testModel.get('datasetCollections').NWIS;
 			testPrecipCollection = testModel.get('datasetCollections').PRECIP;
 


### PR DESCRIPTION
Updated the workflow model's updateDataSetCollections event handler to only refetch datasets if it is necessary. If the bounding box changes than all chosen datasets are refetched. If the datasets property changes, only the datasets added are fetched and only the datasets removed are cleared. In addition, the updateModelStep was modified to only issue signals when needed to update the datasetCollections.

The select2 picker doesn't play well with backbone.stickit so uses DOM event handlers and model event handlers directly to implement the two-way binding. Also initializing the options with the template rather than during the select2 setup.