### PR TITLE
Enddat 139 date

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,8 @@
     "leaflet-providers": "^1.1.7",
     "loglevel": "^1.4.0",
     "backbone.stickit": "^0.9.2",
-    "moment": "^2.12.0"
+    "moment": "^2.12.0",
+    "eonasdan-bootstrap-datetimepicker": "^4.17.37"
   },
   "resolutions": {
     "underscore": "~1.8.3",

--- a/src/main/webapp/dataDiscovery.jsp
+++ b/src/main/webapp/dataDiscovery.jsp
@@ -51,7 +51,8 @@
 					'leaflet-providers' : '<%=baseUrl%>bower_components/leaflet-providers/leaflet-providers',
 					'loglevel' : '<%=baseUrl%>bower_components/loglevel/dist/loglevel<%= development ? "" : ".min"%>',
 					'backbone.stickit' : '<%=baseUrl%>bower_components/backbone.stickit/backbone.stickit',
-					'moment' : '<%=baseUrl%>bower_components/moment/<%=development ? "" : "min/"%>moment<%=development ? "" : ".min"%>'
+					'moment' : '<%=baseUrl%>bower_components/moment/<%=development ? "" : "min/"%>moment<%=development ? "" : ".min"%>',
+					'bootstrap-datetimepicker' : '<%=baseUrl%>bower_components/eonasdan-bootstrap-datetimepicker.src/js/bootstrap-datetimepicker'
 				},
 				shim: {
 					"bootstrap": [ "jquery" ],
@@ -67,7 +68,8 @@
 						deps: ['jquery', 'underscore', 'backbone'],
 						exports: 'Backgrid'
 					},
-					'backbone.stickit' : ['backbone', 'underscore']
+					'backbone.stickit' : ['backbone', 'underscore'],
+					'bootstrap-datetimepicker' : ['jquery', 'bootstrap', 'moment']
 				},
 				packages : [
 					{

--- a/src/main/webapp/dataDiscovery.jsp
+++ b/src/main/webapp/dataDiscovery.jsp
@@ -52,7 +52,7 @@
 					'loglevel' : '<%=baseUrl%>bower_components/loglevel/dist/loglevel<%= development ? "" : ".min"%>',
 					'backbone.stickit' : '<%=baseUrl%>bower_components/backbone.stickit/backbone.stickit',
 					'moment' : '<%=baseUrl%>bower_components/moment/<%=development ? "" : "min/"%>moment<%=development ? "" : ".min"%>',
-					'bootstrap-datetimepicker' : '<%=baseUrl%>bower_components/eonasdan-bootstrap-datetimepicker.src/js/bootstrap-datetimepicker'
+					'bootstrap-datetimepicker' : '<%=baseUrl%>bower_components/eonasdan-bootstrap-datetimepicker/src/js/bootstrap-datetimepicker'
 				},
 				shim: {
 					"bootstrap": [ "jquery" ],

--- a/src/main/webapp/js/controller/AppRouter.js
+++ b/src/main/webapp/js/controller/AppRouter.js
@@ -4,10 +4,13 @@ define([
 	'jquery',
 	'backbone',
 	'loglevel',
+	'moment',
 	'models/WorkflowStateModel',
 	'views/DataDiscoveryView'
-], function ($, Backbone, log, WorkflowStateModel, DataDiscoveryView) {
+], function ($, Backbone, log, moment, WorkflowStateModel, DataDiscoveryView) {
 	"use strict";
+
+	var DATE_FORMAT = 'DMMMYYYY';
 
 	var appRouter = Backbone.Router.extend({
 		routes: {
@@ -61,8 +64,8 @@ define([
 			this.workflowState.set({
 				'location' : {latitude : lat, longitude : lng},
 				'radius' : radius,
-				'startDate' : startDate,
-				'endDate' : endDate
+				'startDate' : (startDate) ? moment(startDate, DATE_FORMAT) : '',
+				'endDate' : (endDate) ? moment(endDate, DATE_FORMAT) : ''
 			});
 			this.workflowState.set('step', this.workflowState.CHOOSE_DATA_STEP);
 			this.createView(DataDiscoveryView, {

--- a/src/main/webapp/js/hb_templates/choose.hbs
+++ b/src/main/webapp/js/hb_templates/choose.hbs
@@ -3,6 +3,22 @@
 		<label for="radius">Radius</label>
 		<input id="radius" class="form-control" type="number" min="0" max="500" step="any" value="{{radius}}"/>
 	</div>
+	<div class="form-inline">
+		<div class="form-group">
+			<label class="control-label" for="start-date">Start Date</label>
+			<div class="input-group date" id="start-date-div" >
+				<input type="text" id="start-date" class="form-control" size="10"/>
+				<span class="input-group-addon"><i class="fa fa-calendar"></i></span>
+			</div>
+		</div>
+		<div class="form-group">
+			<label class="control-label" for="end-date">End Date</label>
+			<div class="input-group date" id="end-date-div">
+				<input type="text" id="end-date" class="form-control" size="10"/>
+				<span class="input-group-addon"><i class="fa fa-calendar"></i></span>
+			</div>
+		</div>
+	</div>
 	<div class="form-group">
 		<label for="datasets-select">Datasets</label>
 		<select id="datasets-select" class="form-control" multiple>

--- a/src/main/webapp/js/models/BaseDatasetCollection.js
+++ b/src/main/webapp/js/models/BaseDatasetCollection.js
@@ -1,0 +1,39 @@
+/* jslint browser: true */
+
+define([
+	'underscore',
+	'backbone',
+	'utils/dateUtils'
+], function(_, Backbone, dateUtils) {
+
+	var model = Backbone.Collection.extend({
+
+		getModelsWithinDateFilter : function(startDate, endDate) {
+			var dateFilter;
+			var result;
+
+			if ((startDate) && (endDate)) {
+				dateFilter = {
+					start : new Date(startDate),
+					end : new Date(endDate)
+				};
+				result = this.filter(function(model) {
+					var modelDateRange = {
+						start : new Date(model.get('startDate')),
+						end : new Date(model.get('endDate'))
+					};
+					return dateUtils.dateRangeOverlaps(modelDateRange, dateFilter);
+				});
+			}
+			else {
+				result = this.toArray();
+			}
+
+			return result;
+		}
+	});
+
+	return model;
+});
+
+

--- a/src/main/webapp/js/models/BaseDatasetCollection.js
+++ b/src/main/webapp/js/models/BaseDatasetCollection.js
@@ -8,19 +8,27 @@ define([
 
 	var model = Backbone.Collection.extend({
 
+
+		/*
+		 * The startDate and endDate values in each model are assumed to be moment objects
+		 * @param {Moment} startDate
+		 * @param {Moment} endDate
+		 * @returns {Arra of Backbone.Model} whose startDate and endDate range overlaps the function parameters.
+		 *		If startDate or endDate are falsy, all of the models in the collection are returned.
+		 */
 		getModelsWithinDateFilter : function(startDate, endDate) {
 			var dateFilter;
 			var result;
 
 			if ((startDate) && (endDate)) {
 				dateFilter = {
-					start : new Date(startDate),
-					end : new Date(endDate)
+					start : startDate,
+					end : endDate
 				};
 				result = this.filter(function(model) {
 					var modelDateRange = {
-						start : new Date(model.get('startDate')),
-						end : new Date(model.get('endDate'))
+						start : model.get('startDate'),
+						end : model.get('endDate')
 					};
 					return dateUtils.dateRangeOverlaps(modelDateRange, dateFilter);
 				});

--- a/src/main/webapp/js/models/BaseDatasetCollection.js
+++ b/src/main/webapp/js/models/BaseDatasetCollection.js
@@ -13,7 +13,7 @@ define([
 		 * The startDate and endDate values in each model are assumed to be moment objects
 		 * @param {Moment} startDate
 		 * @param {Moment} endDate
-		 * @returns {Arra of Backbone.Model} whose startDate and endDate range overlaps the function parameters.
+		 * @returns {Array of Backbone.Model} whose startDate and endDate range overlaps the function parameters.
 		 *		If startDate or endDate are falsy, all of the models in the collection are returned.
 		 */
 		getModelsWithinDateFilter : function(startDate, endDate) {

--- a/src/main/webapp/js/models/PrecipitationCollection.js
+++ b/src/main/webapp/js/models/PrecipitationCollection.js
@@ -14,7 +14,7 @@ define([
 		return str.split('.')[0];
 	};
 
-	var START_DATE = '2002-01-01';
+	var START_DATE = moment('2002-01-01', 'YYYY-MM-DD');
 
 	var collection = BaseDatasetCollection.extend({
 
@@ -27,7 +27,7 @@ define([
 		 */
 		parse : function(xml) {
 			var result = [];
-			var today = moment().format('YYYY-MM-DD');
+			var today = moment();
 			$utils.xmlFind($(xml), 'wfs', 'member').each(function() {
 				var $this = $(this);
 

--- a/src/main/webapp/js/models/PrecipitationCollection.js
+++ b/src/main/webapp/js/models/PrecipitationCollection.js
@@ -4,10 +4,10 @@ define([
 	'loglevel',
 	'module',
 	'jquery',
-	'backbone',
 	'moment',
+	'models/BaseDatasetCollection',
 	'utils/jqueryUtils'
-], function(log, module, $, Backbone, moment, $utils) {
+], function(log, module, $, moment, BaseDatasetCollection, $utils) {
 	"use strict";
 
 	var getInteger = function(str) {
@@ -16,7 +16,7 @@ define([
 
 	var START_DATE = '2002-01-01';
 
-	var collection = Backbone.Collection.extend({
+	var collection = BaseDatasetCollection.extend({
 
 		url : module.config().precipWFSGetFeatureUrl,
 

--- a/src/main/webapp/js/models/SiteCollection.js
+++ b/src/main/webapp/js/models/SiteCollection.js
@@ -3,17 +3,19 @@
 define([
 	'jquery',
 	'underscore',
-	'backbone',
+	'moment',
 	'loglevel',
 	'module',
-	'utils/rdbUtils'
-], function ($, _, Backbone, log, module, rdbUtils) {
+	'models/BaseDatasetCollection',
+	'utils/rdbUtils',
+	'utils/dateUtils'
+], function ($, _, moment, log, module, BaseDatasetCollection, rdbUtils, dateUtils) {
 	"use strict";
 
 	var config = module.config();
 	var parameterCodesPath = config.parameterCodesPath;
 
-	var model = Backbone.Collection.extend({
+	var model = BaseDatasetCollection.extend({
 
 		url: '',
 

--- a/src/main/webapp/js/utils/dateUtils.js
+++ b/src/main/webapp/js/utils/dateUtils.js
@@ -7,15 +7,20 @@ define([
 		var self = {};
 
 		/*
-		 * @param {String} dateToTest - date Object
-		 * @param {Object with start and end string properties} dateRange - properties should be date objects
+		 * @param {Moment} dateToTest
+		 * @param {Object with start and end string properties} dateRange - properties should be parsable into Momenet objects
 		 * @returns {Boolean} - True if dateToTest is with dateRange.start and dateRange.end inclusive
 		 */
 		self.inDateRange = function(dateToTest, dateRange) {
-			var momentToTest = moment(dateToTest);
-			return (momentToTest.isSameOrAfter(dateRange.start) && momentToTest.isSameOrBefore(dateRange.end));
+			return (dateToTest.isSameOrAfter(dateRange.start) &&
+				dateToTest.isSameOrBefore(dateRange.end));
 		};
 
+		/*
+		 * @param {Object with start and end Moment properties} dateRange1
+		 * @param {Object with start and end Moment properties} dateRange2
+		 * @returns {Boolean} - True if dateRange1 intersects dateRange2
+		 */
 		self.dateRangeOverlaps = function(dateRange1, dateRange2) {
 			return (self.inDateRange(dateRange1.start, dateRange2) ||
 				self.inDateRange(dateRange1.end, dateRange2) ||

--- a/src/main/webapp/js/utils/dateUtils.js
+++ b/src/main/webapp/js/utils/dateUtils.js
@@ -1,0 +1,31 @@
+/* jslint browser */
+
+define([
+	'moment'
+], function(moment) {
+	var utils = (function() {
+		var self = {};
+
+		/*
+		 * @param {String} dateToTest - date Object
+		 * @param {Object with start and end string properties} dateRange - properties should be date objects
+		 * @returns {Boolean} - True if dateToTest is with dateRange.start and dateRange.end inclusive
+		 */
+		self.inDateRange = function(dateToTest, dateRange) {
+			var momentToTest = moment(dateToTest);
+			return (momentToTest.isSameOrAfter(dateRange.start) && momentToTest.isSameOrBefore(dateRange.end));
+		};
+
+		self.dateRangeOverlaps = function(dateRange1, dateRange2) {
+			return (self.inDateRange(dateRange1.start, dateRange2) ||
+				self.inDateRange(dateRange1.end, dateRange2) ||
+				(self.inDateRange(dateRange2.start, dateRange1) && self.inDateRange(dateRange2.end, dateRange1)));
+		};
+
+		return self;
+	})();
+
+	return utils;
+});
+
+

--- a/src/main/webapp/js/views/ChooseView.js
+++ b/src/main/webapp/js/views/ChooseView.js
@@ -4,11 +4,12 @@ define([
 	'underscore',
 	'jquery',
 	'select2',
+	'moment',
 	'bootstrap-datetimepicker',
 	'backbone.stickit',
 	'views/BaseCollapsiblePanelView',
 	'hbs!hb_templates/choose'
-], function(_, $, select2, datetimepicker, stickit, BaseCollapsiblePanelView, hbTemplate) {
+], function(_, $, select2, moment, datetimepicker, stickit, BaseCollapsiblePanelView, hbTemplate) {
 	"use strict";
 
 	/*
@@ -18,6 +19,9 @@ define([
 	 *		@prop {Jquery el or selector} el
 	 *		@prop {Boolean} opened - Set to true if the panel should initially be open.
 	 */
+
+	var DATE_FORMAT = 'YYYY-MM-DD';
+
 	var view = BaseCollapsiblePanelView.extend({
 		template : hbTemplate,
 
@@ -33,9 +37,7 @@ define([
 		},
 
 		bindings : {
-			'#radius' : 'radius',
-			'#start-date' : 'startDate',
-			'#end-date' : 'endDate'
+			'#radius' : 'radius'
 		},
 
 
@@ -62,8 +64,12 @@ define([
 				theme : 'bootstrap'
 			});
 			this.updateDatasets();
+			this.updateStartDate();
+			this.updateEndDate();
 
 			this.listenTo(this.model, 'change:datasets', this.updateDatasets);
+			this.listenTo(this.model, 'change:startDate', this.updateStartDate);
+			this.listenTo(this.model, 'change:endDate', this.updateEndDate);
 			return this;
 		},
 
@@ -74,6 +80,20 @@ define([
 		updateDatasets : function() {
 			var chosenDatasets = (this.model.has('datasets')) ? this.model.get('datasets') : [];
 			this.$('#datasets-select').val(chosenDatasets).trigger('change');
+		},
+
+		updateStartDate : function() {
+			var startDate = (this.model.has('startDate')) ? this.model.get('startDate') : '';
+			var newValue = (startDate) ? startDate.format(DATE_FORMAT) : '';
+
+			this.$('#start-date').val(newValue);
+		},
+
+		updateEndDate : function() {
+			var endDate = (this.model.has('endDate')) ? this.model.get('endDate') : '';
+			var newValue = (endDate) ? endDate.format(DATE_FORMAT) : '';
+
+			this.$('#end-date').val(newValue);
 		},
 
 		/*
@@ -97,7 +117,7 @@ define([
 		changeStartDate : function(ev) {
 			var $endDate = this.$('#end-date-div');
 			if (ev.date) {
-				this.model.set('startDate', ev.date.format('YYYY-MM-DD'));
+				this.model.set('startDate', moment(ev.date));
 				$endDate.data('DateTimePicker').minDate(ev.date);
 			}
 			else {
@@ -109,7 +129,7 @@ define([
 		changeEndDate : function(ev) {
 			var $startDate = this.$('#start-date-div');
 			if (ev.date) {
-				this.model.set('endDate', ev.date.format('YYYY-MM-DD'));
+				this.model.set('endDate', moment(ev.date));
 				$startDate.data('DateTimePicker').maxDate(ev.date);
 			}
 			else {

--- a/src/main/webapp/js/views/ChooseView.js
+++ b/src/main/webapp/js/views/ChooseView.js
@@ -4,10 +4,11 @@ define([
 	'underscore',
 	'jquery',
 	'select2',
+	'bootstrap-datetimepicker',
 	'backbone.stickit',
 	'views/BaseCollapsiblePanelView',
 	'hbs!hb_templates/choose'
-], function(_, $, select2, stickit, BaseCollapsiblePanelView, hbTemplate) {
+], function(_, $, select2, datetimepicker, stickit, BaseCollapsiblePanelView, hbTemplate) {
 	"use strict";
 
 	/*
@@ -25,17 +26,36 @@ define([
 
 		additionalEvents : {
 			'select2:select #datasets-select' : 'selectDataset',
-			'select2:unselect #datasets-select' : 'resetDataset'
+			'select2:unselect #datasets-select' : 'resetDataset',
+			// To set the model value from a datetimepicker, handle the event of the input's div
+			'dp.change #start-date-div' : 'changeStartDate',
+			'dp.change #end-date-div' : 'changeEndDate'
 		},
 
 		bindings : {
-			'#radius' : 'radius'
+			'#radius' : 'radius',
+			'#start-date' : 'startDate',
+			'#end-date' : 'endDate'
 		},
 
 
 		render : function() {
+			var now = new Date();
+
 			BaseCollapsiblePanelView.prototype.render.apply(this, arguments);
 			this.stickit();
+
+			//Set up date pickers
+			this.$('#start-date-div').datetimepicker({
+				format : 'YYYY-MM-DD',
+				useCurrent: false,
+				maxDate : now
+			});
+			this.$('#end-date-div').datetimepicker({
+				format : 'YYYY-MM-DD',
+				useCurrent : false,
+				maxDate : now
+			});
 
 			this.$('#datasets-select').select2({
 				allowClear : true,
@@ -47,10 +67,18 @@ define([
 			return this;
 		},
 
+		/*
+		 * Model event handlers
+		 */
+
 		updateDatasets : function() {
 			var chosenDatasets = (this.model.has('datasets')) ? this.model.get('datasets') : [];
 			this.$('#datasets-select').val(chosenDatasets).trigger('change');
 		},
+
+		/*
+		 * DOM event handlers
+		 */
 
 		selectDataset : function(ev) {
 			var datasets = _.clone((this.model.has('datasets')) ? this.model.get('datasets') : []);
@@ -64,6 +92,30 @@ define([
 				return (ev.params.data.id === datasetKind);
 			});
 			this.model.set('datasets', datasets);
+		},
+
+		changeStartDate : function(ev) {
+			var $endDate = this.$('#end-date-div');
+			if (ev.date) {
+				this.model.set('startDate', ev.date.format('YYYY-MM-DD'));
+				$endDate.data('DateTimePicker').minDate(ev.date);
+			}
+			else {
+				this.model.unset('startDate');
+				$endDate.data('DateTimePicker').minDate(false);
+			}
+		},
+
+		changeEndDate : function(ev) {
+			var $startDate = this.$('#start-date-div');
+			if (ev.date) {
+				this.model.set('endDate', ev.date.format('YYYY-MM-DD'));
+				$startDate.data('DateTimePicker').maxDate(ev.date);
+			}
+			else {
+				this.model.unset('endDate');
+				$startDate.data('DateTimePicker').maxDate(new Date());
+			}
 		}
 
 	});

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -225,6 +225,8 @@ define([
 			this.updateSiteMarker(datasetCollections[model.NWIS_DATASET]);
 			this.updatePrecipGridPoints(datasetCollections[model.PRECIP_DATASET]);
 
+			this.listenTo(model, 'change:startDate', this.updateDatasetDateFilter);
+			this.listenTo(model, 'change:endDate', this.updateDatasetDateFilter);
 			this.listenTo(datasetCollections[model.NWIS_DATASET], 'reset', this.updateSiteMarker);
 			this.listenTo(datasetCollections[model.PRECIP_DATASET], 'reset', this.updatePrecipGridPoints);
 		},

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -9,8 +9,7 @@ define([
 ], function(_, bootstrap, log, BaseView, hb_template) {
 	"use strict";
 
-	var DEFAULT_RADIUS = 2;
-	var DEFAULT_DATASETS = ['NWIS'];
+	var DATE_FORMAT = 'YYYY-MM-DD';
 
 	var view = BaseView.extend({
 		template : hb_template,
@@ -73,8 +72,8 @@ define([
 
 			var location = 'lat/' + latitude + '/lng/' + longitude;
 			var radius = (model.has('radius')) ? '/radius/' + state.radius : '';
-			var startDate = (model.has('startDate')) ? '/startdate/' + state.startDate : '';
-			var endDate = (model.has('endDate')) ? '/enddate/' + state.endDate : '';
+			var startDate = (model.has('startDate')) ? '/startdate/' + state.startDate.format(DATE_FORMAT) : '';
+			var endDate = (model.has('endDate')) ? '/enddate/' + state.endDate.format(DATE_FORMAT) : '';
 			var datasets = (model.has('datasets')) ? '/dataset/' + state.datasets.join('/') : '';
 			return location + radius + startDate + endDate + datasets;
 		},

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -9,7 +9,7 @@ define([
 ], function(_, bootstrap, log, BaseView, hb_template) {
 	"use strict";
 
-	var DATE_FORMAT = 'YYYY-MM-DD';
+	var DATE_FORMAT = 'DMMMYYYY';
 
 	var view = BaseView.extend({
 		template : hb_template,
@@ -71,10 +71,10 @@ define([
 			var longitude = (_.has(state, 'location') && _.has(state.location, 'longitude')) ? state.location.longitude : '';
 
 			var location = 'lat/' + latitude + '/lng/' + longitude;
-			var radius = (model.has('radius')) ? '/radius/' + state.radius : '';
-			var startDate = (model.has('startDate')) ? '/startdate/' + state.startDate.format(DATE_FORMAT) : '';
-			var endDate = (model.has('endDate')) ? '/enddate/' + state.endDate.format(DATE_FORMAT) : '';
-			var datasets = (model.has('datasets')) ? '/dataset/' + state.datasets.join('/') : '';
+			var radius = (state.radius) ? '/radius/' + state.radius : '';
+			var startDate = (state.startDate) ? '/startdate/' + state.startDate.format(DATE_FORMAT) : '';
+			var endDate = (state.endDate) ? '/enddate/' + state.endDate.format(DATE_FORMAT) : '';
+			var datasets = (state.datasets) ? '/dataset/' + state.datasets.join('/') : '';
 			return location + radius + startDate + endDate + datasets;
 		},
 

--- a/src/main/webapp/less/custom.less
+++ b/src/main/webapp/less/custom.less
@@ -3,7 +3,7 @@
 @import "../bower_components/font-awesome/less/font-awesome.less";
 @import "../bower_components/eonasdan-bootstrap-datetimepicker/src/less/_bootstrap-datetimepicker.less";
 
-@icon-font-path : "../bower/bootstrap/fonts/";
+@icon-font-path : "../bower_components/bootstrap/fonts/";
 @fa-font-path : "../bower_components/font-awesome/fonts";
 #header #banner-area {
 	font-family : Verdana, Arial, Helvetica, sans-serif;

--- a/src/main/webapp/less/custom.less
+++ b/src/main/webapp/less/custom.less
@@ -1,6 +1,7 @@
 @import "../bower_components/bootstrap/less/bootstrap.less";
 @import "../bower_components/select2-bootstrap-theme/src/select2-bootstrap.less";
 @import "../bower_components/font-awesome/less/font-awesome.less";
+@import "../bower_components/eonasdan-bootstrap-datetimepicker/src/less/_bootstrap-datetimepicker.less";
 
 @icon-font-path : "../bower/bootstrap/fonts/";
 @fa-font-path : "../bower_components/font-awesome/fonts";

--- a/src/test/js/karma.conf.js
+++ b/src/test/js/karma.conf.js
@@ -25,6 +25,7 @@ module.exports = function (config) {
 			{pattern: 'src/main/webapp/bower_components/loglevel/dist/loglevel.js', included: false},
 			{pattern: 'src/main/webapp/bower_components/backbone.stickit/backbone.stickit.js', included : false},
 			{pattern: 'src/main/webapp/bower_components/moment/moment.js', included : false},
+			{pattern: 'src/main/webapp/bower_components/eonasdan-bootstrap-datetimepicker/js/bootstrap-datetimepicker.js', included : false},
 			{pattern: 'src/main/webapp/js/*/*.js', included: false},
 			{pattern: 'src/main/webapp/js/hb_templates/*.hbs', included: false},
 			{pattern: 'src/test/js/views/*.js', included: false},

--- a/src/test/js/karma.conf.js
+++ b/src/test/js/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function (config) {
 			{pattern: 'src/main/webapp/bower_components/loglevel/dist/loglevel.js', included: false},
 			{pattern: 'src/main/webapp/bower_components/backbone.stickit/backbone.stickit.js', included : false},
 			{pattern: 'src/main/webapp/bower_components/moment/moment.js', included : false},
-			{pattern: 'src/main/webapp/bower_components/eonasdan-bootstrap-datetimepicker/js/bootstrap-datetimepicker.js', included : false},
+			{pattern: 'src/main/webapp/bower_components/eonasdan-bootstrap-datetimepicker/src/js/bootstrap-datetimepicker.js', included : false},
 			{pattern: 'src/main/webapp/js/*/*.js', included: false},
 			{pattern: 'src/main/webapp/js/hb_templates/*.hbs', included: false},
 			{pattern: 'src/test/js/views/*.js', included: false},

--- a/src/test/js/models/BaseDatasetCollectionSpec.js
+++ b/src/test/js/models/BaseDatasetCollectionSpec.js
@@ -2,38 +2,40 @@
 /* global expect */
 
 define([
+	'moment',
 	'models/BaseDatasetCollection'
-], function(BaseDatasetCollection) {
+], function(moment, BaseDatasetCollection) {
 
-	fdescribe('models/BaseDatasetCollection', function() {
+	describe('models/BaseDatasetCollection', function() {
 
 		describe('Tests for getModelsWithinDateFilter', function() {
 
 			var testModel;
+			var DATE_FORMAT = 'MM-DD-YYYY';
 
 			beforeEach(function() {
 				testModel = new BaseDatasetCollection([
-					{id : 1, startDate : '01-01-2000', endDate : '01-01-2010'},
-					{id : 2, startDate : '01-01-2001', endDate : '01-01-2011'},
-					{id : 3, startDate : '01-01-2005', endDate : '01-01-2007'},
-					{id : 4, startDate : '01-01-2008', endDate : '01-01-2012'}
+					{id : 1, startDate : moment('01-01-2000', DATE_FORMAT), endDate : moment('01-01-2010', DATE_FORMAT)},
+					{id : 2, startDate : moment('01-01-2001', DATE_FORMAT), endDate : moment('01-01-2011', DATE_FORMAT)},
+					{id : 3, startDate : moment('01-01-2005', DATE_FORMAT), endDate : moment('01-01-2007', DATE_FORMAT)},
+					{id : 4, startDate : moment('01-01-2008', DATE_FORMAT), endDate : moment('01-01-2012', DATE_FORMAT)}
 				]);
 			});
 
 			it ('Expects that if either the startDate or endDate is falsy, the entire collection is returned', function() {
-				expect(testModel.getModelsWithinDateFilter('01-01-2003', '').length).toBe(4);
-				expect(testModel.getModelsWithinDateFilter('', '01-01-2003').length).toBe(4);
+				expect(testModel.getModelsWithinDateFilter(moment('01-01-2003', DATE_FORMAT), '').length).toBe(4);
+				expect(testModel.getModelsWithinDateFilter('', moment('01-01-2003', DATE_FORMAT)).length).toBe(4);
 			});
 
 			it('Expects that only models within the date range will be returned', function() {
 				var results;
-				results = testModel.getModelsWithinDateFilter('03-01-2003', '01-01-2004');
+				results = testModel.getModelsWithinDateFilter(moment('03-01-2003', DATE_FORMAT), moment('01-01-2004', DATE_FORMAT));
 				expect(results.length).toBe(2);
 
-				results = testModel.getModelsWithinDateFilter('01-01-1999', '01-01-2014');
+				results = testModel.getModelsWithinDateFilter(moment('01-01-1999', DATE_FORMAT), moment('01-01-2014', DATE_FORMAT));
 				expect(results.length).toBe(4);
 
-				results = testModel.getModelsWithinDateFilter('01-01-2013', '01-01-2015');
+				results = testModel.getModelsWithinDateFilter(moment('01-01-2013', DATE_FORMAT), moment('01-01-2015', DATE_FORMAT));
 				expect(results.length).toBe(0);
 			});
 		});

--- a/src/test/js/models/BaseDatasetCollectionSpec.js
+++ b/src/test/js/models/BaseDatasetCollectionSpec.js
@@ -1,0 +1,41 @@
+/* jslint browser */
+/* global expect */
+
+define([
+	'models/BaseDatasetCollection'
+], function(BaseDatasetCollection) {
+
+	fdescribe('models/BaseDatasetCollection', function() {
+
+		describe('Tests for getModelsWithinDateFilter', function() {
+
+			var testModel;
+
+			beforeEach(function() {
+				testModel = new BaseDatasetCollection([
+					{id : 1, startDate : '01-01-2000', endDate : '01-01-2010'},
+					{id : 2, startDate : '01-01-2001', endDate : '01-01-2011'},
+					{id : 3, startDate : '01-01-2005', endDate : '01-01-2007'},
+					{id : 4, startDate : '01-01-2008', endDate : '01-01-2012'}
+				]);
+			});
+
+			it ('Expects that if either the startDate or endDate is falsy, the entire collection is returned', function() {
+				expect(testModel.getModelsWithinDateFilter('01-01-2003', '').length).toBe(4);
+				expect(testModel.getModelsWithinDateFilter('', '01-01-2003').length).toBe(4);
+			});
+
+			it('Expects that only models within the date range will be returned', function() {
+				var results;
+				results = testModel.getModelsWithinDateFilter('03-01-2003', '01-01-2004');
+				expect(results.length).toBe(2);
+
+				results = testModel.getModelsWithinDateFilter('01-01-1999', '01-01-2014');
+				expect(results.length).toBe(4);
+
+				results = testModel.getModelsWithinDateFilter('01-01-2013', '01-01-2015');
+				expect(results.length).toBe(0);
+			});
+		});
+	});
+});

--- a/src/test/js/test-main.js
+++ b/src/test/js/test-main.js
@@ -33,7 +33,7 @@ require.config({
 		'loglevel' : '/base/src/main/webapp/bower_components/loglevel/dist/loglevel',
 		'backbone.stickit' : '/base/src/main/webapp/bower_components/backbone.stickit/backbone.stickit',
 		'moment' : '/base/src/main/webapp/bower_components/moment/moment',
-		'bootstrap-datetimepicker' : '/base/src/main/webapp/bower_components/eonasdan-bootstrap-datetimepicker.src/js/bootstrap-datetimepicker'
+		'bootstrap-datetimepicker' : '/base/src/main/webapp/bower_components/eonasdan-bootstrap-datetimepicker/src/js/bootstrap-datetimepicker'
 	},
 	shim: {
 		'bootstrap': ['jquery'],

--- a/src/test/js/test-main.js
+++ b/src/test/js/test-main.js
@@ -32,7 +32,8 @@ require.config({
 		'leaflet-providers' : '/base/src/main/webapp/bower_components/leaflet-providers/leaflet-providers',
 		'loglevel' : '/base/src/main/webapp/bower_components/loglevel/dist/loglevel',
 		'backbone.stickit' : '/base/src/main/webapp/bower_components/backbone.stickit/backbone.stickit',
-		'moment' : '/base/src/main/webapp/bower_components/moment/moment'
+		'moment' : '/base/src/main/webapp/bower_components/moment/moment',
+		'bootstrap-datetimepicker' : '/base/src/main/webapp/bower_components/eonasdan-bootstrap-datetimepicker.src/js/bootstrap-datetimepicker'
 	},
 	shim: {
 		'bootstrap': ['jquery'],
@@ -48,7 +49,8 @@ require.config({
 			deps: ['jquery', 'underscore', 'backbone'],
 			exports: 'Backgrid'
 		},
-		'backbone.stickit' : ['backbone', 'underscore']
+		'backbone.stickit' : ['backbone', 'underscore'],
+		'bootstrap-datetimepicker' : ['jquery', 'bootstrap', 'moment']
 	}
 });
 require(allTestFiles, window.__karma__.start);

--- a/src/test/js/utils/dateUtilsSpec.js
+++ b/src/test/js/utils/dateUtilsSpec.js
@@ -2,77 +2,80 @@
 /* global expect */
 
 define([
+	'moment',
 	'utils/dateUtils'
-], function(dateUtils) {
+], function(moment, dateUtils) {
 	describe('utils/dateUtils', function() {
+		var DATE_FORMAT = 'YYYY-MM-DD';
+
 		describe('Tests for inDateRange', function() {
 			var dateRange = {
-				start : new Date('01-01-2010'),
-				end : new Date('03-01-2015')
+				start : moment('2010-01-01', DATE_FORMAT),
+				end : moment('2015-03-01', DATE_FORMAT)
 			};
 
 			it('Expects that if a date is outside dateRange, false is returned', function() {
-				expect(dateUtils.inDateRange(new Date('12-31-2009'), dateRange)).toBe(false);
-				expect(dateUtils.inDateRange(new Date('03-02-2015'), dateRange)).toBe(false);
+				expect(dateUtils.inDateRange(moment ('2009-12-31', DATE_FORMAT), dateRange)).toBe(false);
+				expect(dateUtils.inDateRange(moment('2015-03-02', DATE_FORMAT), dateRange)).toBe(false);
 			});
 
 			it('Expects that a date within the dateRange returns true', function() {
-				expect(dateUtils.inDateRange(new Date('06-23-2012'), dateRange)).toBe(true);
-				expect(dateUtils.inDateRange(new Date('01-01-2010'), dateRange)).toBe(true);
-				expect(dateUtils.inDateRange(new Date('03-01-2015'), dateRange)).toBe(true);
+				expect(dateUtils.inDateRange(moment('2012-06-23', DATE_FORMAT), dateRange)).toBe(true);
+				expect(dateUtils.inDateRange(moment('2010-01-01', DATE_FORMAT), dateRange)).toBe(true);
+				expect(dateUtils.inDateRange(moment('2015-03-01', DATE_FORMAT), dateRange)).toBe(true);
 			});
 		});
 
 		describe('Tests for dateRangeOverlaps', function() {
 			var dateRange2 = {
-				start : new Date('01-01-2010'),
-				end : new Date('03-01-2015')
+				start : moment('2010-01-01', DATE_FORMAT),
+				end : moment('2015-03-01', DATE_FORMAT)
 			};
 
 			it('Expects that a date range that starts before but ends during dateRange2 returns true', function() {
 				var dateRange1 = {
-					start : new Date('12-12-2009'),
-					end : new Date('04-01-2014')
+					start : moment('2009-12-12', DATE_FORMAT),
+					end : moment('2014-04-01', DATE_FORMAT)
 				};
 				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(true);
 			});
 
 			it('Expects that a date range that starts after but ends after dateRange2 returns true', function() {
 				var dateRange1 = {
-					start : new Date('12-12-2010'),
-					end : new Date('04-01-2015')
+					start : moment('2010-12-12', DATE_FORMAT),
+					end : moment('2015-04-01', DATE_FORMAT)
 				};
 				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(true);
 			});
 
 			it('Expects that a date range completely within dateRange2 returns true', function() {
 				var dateRange1 = {
-					start : new Date('12-12-2010'),
-					end : new Date('04-01-2014')
+					start : moment('2010-12-12', DATE_FORMAT),
+					end : moment('2014-04-01', DATE_FORMAT)
 				};
 				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(true);
 			});
 
 			it('Expects that a date range where start begins before dateRange2 and ends after returns true', function() {
 				var dateRange1 = {
-					start : new Date('12-12-2009'),
-					end : new Date('04-01-2016')
+					start : moment('2009-12-12', DATE_FORMAT),
+					end : moment('2016-04-01', DATE_FORMAT)
 				};
 				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(true);
 			});
 
 			it('Expects that a date range that ends before the start of dateRange2 returns false', function() {
 				var dateRange1 = {
-					start : new Date('12-12-2001'),
-					end : new Date('12-12-2009')
+					start : moment('2001-12-12', DATE_FORMAT),
+					end : moment('2009-12-12', DATE_FORMAT)
 				};
 				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(false);
 			});
 
 			it('Expects that a date range that starts after the end of dateRange2 returns false', function() {
 				var dateRange1 = {
-					start : new Date('12-12-2015'),
-					end : new Date('12-12-2015')
+					start : moment('2015-12-12', DATE_FORMAT),
+					end : moment('2016-12-12', DATE_FORMAT)
 				};
 				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(false);
 			});

--- a/src/test/js/utils/dateUtilsSpec.js
+++ b/src/test/js/utils/dateUtilsSpec.js
@@ -1,0 +1,83 @@
+/* jslint browser: true */
+/* global expect */
+
+define([
+	'utils/dateUtils'
+], function(dateUtils) {
+	describe('utils/dateUtils', function() {
+		describe('Tests for inDateRange', function() {
+			var dateRange = {
+				start : new Date('01-01-2010'),
+				end : new Date('03-01-2015')
+			};
+
+			it('Expects that if a date is outside dateRange, false is returned', function() {
+				expect(dateUtils.inDateRange(new Date('12-31-2009'), dateRange)).toBe(false);
+				expect(dateUtils.inDateRange(new Date('03-02-2015'), dateRange)).toBe(false);
+			});
+
+			it('Expects that a date within the dateRange returns true', function() {
+				expect(dateUtils.inDateRange(new Date('06-23-2012'), dateRange)).toBe(true);
+				expect(dateUtils.inDateRange(new Date('01-01-2010'), dateRange)).toBe(true);
+				expect(dateUtils.inDateRange(new Date('03-01-2015'), dateRange)).toBe(true);
+			});
+		});
+
+		describe('Tests for dateRangeOverlaps', function() {
+			var dateRange2 = {
+				start : new Date('01-01-2010'),
+				end : new Date('03-01-2015')
+			};
+
+			it('Expects that a date range that starts before but ends during dateRange2 returns true', function() {
+				var dateRange1 = {
+					start : new Date('12-12-2009'),
+					end : new Date('04-01-2014')
+				};
+				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(true);
+			});
+
+			it('Expects that a date range that starts after but ends after dateRange2 returns true', function() {
+				var dateRange1 = {
+					start : new Date('12-12-2010'),
+					end : new Date('04-01-2015')
+				};
+				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(true);
+			});
+
+			it('Expects that a date range completely within dateRange2 returns true', function() {
+				var dateRange1 = {
+					start : new Date('12-12-2010'),
+					end : new Date('04-01-2014')
+				};
+				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(true);
+			});
+
+			it('Expects that a date range where start begins before dateRange2 and ends after returns true', function() {
+				var dateRange1 = {
+					start : new Date('12-12-2009'),
+					end : new Date('04-01-2016')
+				};
+				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(true);
+			});
+
+			it('Expects that a date range that ends before the start of dateRange2 returns false', function() {
+				var dateRange1 = {
+					start : new Date('12-12-2001'),
+					end : new Date('12-12-2009')
+				};
+				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(false);
+			});
+
+			it('Expects that a date range that starts after the end of dateRange2 returns false', function() {
+				var dateRange1 = {
+					start : new Date('12-12-2015'),
+					end : new Date('12-12-2015')
+				};
+				expect(dateUtils.dateRangeOverlaps(dateRange1, dateRange2)).toBe(false);
+			});
+		});
+	});
+});
+
+

--- a/src/test/js/views/ChooseViewSpec.js
+++ b/src/test/js/views/ChooseViewSpec.js
@@ -4,25 +4,26 @@
 define([
 	'jquery',
 	'select2',
+	'moment',
 	'models/WorkflowStateModel',
 	'views/ChooseView'
-], function($, select2, WorkflowStateModel, ChooseView) {
+], function($, select2, moment, WorkflowStateModel, ChooseView) {
 	"use strict";
 
-	describe('views/ChooseView', function() {
+	fdescribe('views/ChooseView', function() {
 		var testView;
 		var testModel;
 		var $testDiv;
 		var fakeServer;
+
+		var DATE_FORMAT = 'YYYY-MM-DD';
 
 		beforeEach(function() {
 			fakeServer = sinon.fakeServer.create();
 			$('body').append('<div id="test-div"></div>');
 			$testDiv = $('#test-div');
 
-			testModel = new WorkflowStateModel({}, {
-				createDatasetModels : true
-			});
+			testModel = new WorkflowStateModel();
 			testModel.set('step', testModel.PROJ_LOC_STEP);
 
 			testView = new ChooseView({
@@ -40,23 +41,36 @@ define([
 		});
 
 		describe('Tests for render', function() {
-			beforeEach(function() {
-				testView.render();
-			});
-
 			it('Expects a collapsible panel to be rendered', function() {
+				testView.render();
 				var $panel = $testDiv.find('.collapsible-panel');
 				expect($panel.length).toBe(1);
 				expect($panel.find('.panel-heading').html()).toContain('Choose Data');
 			});
+
+			it('Expects the inputs to reflect the values in the model', function() {
+				testModel.set({
+					radius : '2',
+					startDate : moment('2001-01-01', DATE_FORMAT),
+					endDate : moment('2010-01-01', DATE_FORMAT),
+					datasets : [testModel.NWIS_DATASET]
+				});
+				testView.render();
+				expect($testDiv.find('#radius').val()).toEqual('2');
+				expect($testDiv.find('#start-date').val()).toEqual('2001-01-01');
+				expect($testDiv.find('#end-date').val()).toEqual('2010-01-01');
+				expect($testDiv.find('#datasets-select').val()).toEqual([testModel.NWIS_DATASET]);
+			});
 		});
 
 		describe('DOM event handler tests', function() {
-			var $rad, $datasets;
+			var $rad, $datasets, $startDate, $endDate;
 			beforeEach(function() {
 				testView.render();
 				$rad = $testDiv.find('#radius');
 				$datasets = $testDiv.find('#datasets-select');
+				$startDate = $testDiv.find('#start-date');
+				$endDate = $testDiv.find('#end-date');
 
 			});
 
@@ -78,14 +92,26 @@ define([
 				testView.resetDataset(ev);
 				expect(testModel.get('datasets')).toEqual([]);
 			});
+
+			it('Expects that changing the start date updates the model\'s startDate property', function() {
+				$startDate.val('2002-02-15').trigger('change');
+				expect(testModel.get('startDate').format(DATE_FORMAT)).toEqual('2002-02-15');
+			});
+
+			it('Expects that changing the end date updates the model\'s endDate property', function() {
+				$endDate.val('2002-02-15').trigger('change');
+				expect(testModel.get('endDate').format(DATE_FORMAT)).toEqual('2002-02-15');
+			});
 		});
 
 		describe('Model event handlers', function() {
-			var $rad, $datasets;
+			var $rad, $datasets, $startDate, $endDate;
 			beforeEach(function() {
 				testView.render();
 				$rad = $testDiv.find('#radius');
 				$datasets = $testDiv.find('#datasets-select');
+				$startDate = $testDiv.find('#start-date');
+				$endDate = $testDiv.find('#end-date');
 			});
 
 			it('Expects that if the model\'s radius property is updated the radius field is updated', function() {
@@ -97,6 +123,22 @@ define([
 				testModel.set('datasetCollections', {'NWIS': {}});
 				testModel.set('datasets', ['NWIS']);
 				expect($datasets.val()).toEqual(['NWIS']);
+			});
+
+			it('Expects that when the model\'s startDate property is updated, the start date field is updated', function() {
+				testModel.set('startDate', moment('2004-04-01', DATE_FORMAT));
+				expect($startDate.val()).toEqual('2004-04-01');
+
+				testModel.set('startDate', '');
+				expect($startDate.val()).toEqual('');
+			});
+
+			it('Expects that when the model\'s endDate property is updated, the end date field is updated', function() {
+				testModel.set('endDate', moment('2004-04-01', DATE_FORMAT));
+				expect($endDate.val()).toEqual('2004-04-01');
+
+				testModel.set('endDate', '');
+				expect($endDate.val()).toEqual('');
 			});
 		});
 	});

--- a/src/test/js/views/ChooseViewSpec.js
+++ b/src/test/js/views/ChooseViewSpec.js
@@ -10,7 +10,7 @@ define([
 ], function($, select2, moment, WorkflowStateModel, ChooseView) {
 	"use strict";
 
-	fdescribe('views/ChooseView', function() {
+	describe('views/ChooseView', function() {
 		var testView;
 		var testModel;
 		var $testDiv;

--- a/src/test/js/views/NavViewSpec.js
+++ b/src/test/js/views/NavViewSpec.js
@@ -3,10 +3,11 @@
 define([
 	'jquery',
 	'loglevel',
+	'moment',
 	'models/WorkflowStateModel',
 	'views/BaseView',
 	'views/NavView'
-], function($, log, WorkflowStateModel, BaseView, NavView) {
+], function($, log, moment, WorkflowStateModel, BaseView, NavView) {
 	describe('views/NavView', function() {
 		var testView;
 		var testModel;
@@ -17,6 +18,8 @@ define([
 		var projLocSel = '.nav-project-loc';
 		var chooseDataSel = '.nav-choose-data';
 		var processDataSel = '.nav-process-data';
+
+		var DATE_FORMAT = 'DMMMYYYY';
 
 		beforeEach(function() {
 			fakeServer = sinon.fakeServer.create();
@@ -167,7 +170,7 @@ define([
 					radius : '',
 					datasets : []
 				});
-				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/42/lng/-101/radius//dataset/']);
+				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/42/lng/-101/dataset/']);
 			});
 
 			it('Expects that if the step is CHOOSE_DATA and the location becomes invalid that the url is not updated', function() {
@@ -178,7 +181,7 @@ define([
 					datasets : []
 				});
 
-				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/42/lng/-101/radius//dataset/']);
+				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/42/lng/-101/dataset/']);
 
 				mockRouter.navigate.calls.reset();
 				testModel.set('location', {latitude : '', longitude : -101.0});
@@ -199,8 +202,8 @@ define([
 				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/43/lng/-100/radius/2/dataset/NWIS/Precip']);
 
 				testModel.set({
-					startDate : '1Jan2000',
-					endDate : '1Jan2010'
+					startDate : moment('1Jan2000', DATE_FORMAT),
+					endDate : moment('1Jan2010', DATE_FORMAT)
 				});
 				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/43/lng/-100/radius/2/startdate/1Jan2000/enddate/1Jan2010/dataset/NWIS/Precip']);
 				testModel.set('radius', 10);


### PR DESCRIPTION
Added a start and end date input to the Choose Data. Decided that any date saved in a model would be saved as a moment object (javascript library which works with dates across different browsers with different parsing formats). When the date is displayed, the code can specify the formatted needed for display as well as specifying the format when a string date is parsed.

Created BaseDatasetCollection and added a filter function that will return an array of models within the date filter specified. Extended this for both the precip and site collections. Modified the parsing in SiteCollection to produce a startDate/endDate pair for each site model. Within that range there will be at least one variable in the collection that has data for the date range.