### PR TITLE
Fix proj loc

### DIFF
--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -136,15 +136,17 @@ define([
 							collection.reset();
 						});
 					};
-					this.unset('location', {silent : true});
-					this.unset('radius', {silent : true});
-					this.unset('datasets', {silent : true});
+					this.unset('datasets');
+					this.unset('location');
+					this.unset('radius');
+					this.unset('startDate');
+					this.unset('endDate');
 					break;
 
 				case this.CHOOSE_DATA_STEP:
 					if (previousStep === this.PROJ_LOC_STEP) {
 						this.initializeDatasetCollections();
-						this.set('datasets', this.DEFAULT_CHOSEN_DATASETS, {silent: true});
+						this.set('datasets', this.DEFAULT_CHOSEN_DATASETS);
 						this.set('radius', this.DEFAULT_CHOOSE_DATA_RADIUS);
 					}
 					break;

--- a/src/main/webapp/js/views/ChooseView.js
+++ b/src/main/webapp/js/views/ChooseView.js
@@ -49,12 +49,12 @@ define([
 
 			//Set up date pickers
 			this.$('#start-date-div').datetimepicker({
-				format : 'YYYY-MM-DD',
+				format : DATE_FORMAT,
 				useCurrent: false,
 				maxDate : now
 			});
 			this.$('#end-date-div').datetimepicker({
-				format : 'YYYY-MM-DD',
+				format : DATE_FORMAT,
 				useCurrent : false,
 				maxDate : now
 			});

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -1,4 +1,4 @@
-   /* jslint browser : true */
+/* jslint browser : true */
 
 define([
 	'underscore',

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -1,4 +1,4 @@
-/* jslint browser : true */
+   /* jslint browser : true */
 
 define([
 	'underscore',

--- a/src/test/js/models/WorkflowStateModelSpec.js
+++ b/src/test/js/models/WorkflowStateModelSpec.js
@@ -5,8 +5,9 @@ define([
 	'squire',
 	'jquery',
 	'backbone',
+	'moment',
 	'utils/geoSpatialUtils'
-], function(Squire, $, Backbone, geoSpatialUtils) {
+], function(Squire, $, Backbone, moment, geoSpatialUtils) {
 
 	describe('models/WorkflowStateModel', function() {
 		var injector;
@@ -165,10 +166,12 @@ define([
 		});
 
 		describe('Tests for event handlers for updating the workflow step', function() {
-			it('Expects that if the step changes to PROJ_LOC_STEP the location, radius, and datasets properties are unset', function() {
+			it('Expects that if the step changes to PROJ_LOC_STEP the location, radius, dates and datasets properties are unset', function() {
 				testModel.set({
 					location : {latitude : '43.0', longitude : '-100.0'},
 					radius : '6',
+					startDate : moment('2010-04-11', 'YYYY-MM-DD'),
+					endDate : moment('2016-04-15', 'YYYY-MM-DD'),
 					datasets : [testModel.NWIS_DATASET, testModel.PRECIP_DATASET]
 				});
 				testModel.set('step', testModel.PROJ_LOC_STEP);
@@ -176,6 +179,8 @@ define([
 				expect(testModel.has('location')).toBe(false);
 				expect(testModel.has('radius')).toBe(false);
 				expect(testModel.has('datasets')).toBe(false);
+				expect(testModel.has('startDate')).toBe(false);
+				expect(testModel.has('endDate')).toBe(false);
 			});
 
 			it('Expects that if the step changes to PROJ_LOC_STEP the datasetCollections will be cleared', function() {


### PR DESCRIPTION
When updating the workflow step, the rest of the model has to be updated so that events flow through the views. This is why the projection location was not getting cleared when switching the workflow step from Choose Data to Specify Project Location.