### PR TITLE
  Enddat 142

### DIFF
--- a/src/main/webapp/js/hb_templates/dataDiscovery.hbs
+++ b/src/main/webapp/js/hb_templates/dataDiscovery.hbs
@@ -9,5 +9,6 @@
 		<div class="alert-container"></div>
 	</div>
 	<div class="map-container-div"></div>
+	<div class="variable-summary-container"></div>
 </div>
 	

--- a/src/main/webapp/js/hb_templates/nwisData.hbs
+++ b/src/main/webapp/js/hb_templates/nwisData.hbs
@@ -14,9 +14,9 @@
 			</tr>
 		</thead>
 		<tbody>
-			{{#each parameters}}
+			{{#each variables}}
 				<tr>
-					<td><input type="checkbox" {{#if selected}}checked{{/if}} id="toggle-param{{@index}}" /></td>
+					<td><input type="checkbox" {{#if selected}}checked{{/if}} data-id="{{id}}" /></td>
 					<td>{{name}}</td>
 					<td>{{startDate}}</td>
 					<td>{{endDate}}</td>

--- a/src/main/webapp/js/hb_templates/variableSummary.hbs
+++ b/src/main/webapp/js/hb_templates/variableSummary.hbs
@@ -1,4 +1,4 @@
-<div>
+<div class="variable-summary-div">
 	{{#if hasSelectedVariables}}
 		<table class="table">
 			<thead>

--- a/src/main/webapp/js/hb_templates/variableSummary.hbs
+++ b/src/main/webapp/js/hb_templates/variableSummary.hbs
@@ -1,6 +1,6 @@
 <div>
-	{{#if selectedVariables}}
-		<table>
+	{{#if hasSelectedVariables}}
+		<table class="table">
 			<thead>
 				<tr>
 					<th></th>
@@ -12,15 +12,17 @@
 				</tr>
 			</thead>
 			<tbody>
-				{{#each selectedVariables}}
+				{{#each selectedDatasets}}
+					{{#each variables}}
 					<tr>
 						<td><button title="Remove from processing"><i class="fa fa-times"></i></button></td>
-						<td>{{dataset}}</td>
+						<td>{{../datasetName}}</td>
 						<td>{{siteId}}</td>
 						<td>{{startDate}}</td>
 						<td>{{endDate}}</td>
 						<td>{{property}}</td>
 					</tr>
+					{{/each}}
 				{{/each}}
 			</tbody>
 		</table>

--- a/src/main/webapp/js/hb_templates/variableSummary.hbs
+++ b/src/main/webapp/js/hb_templates/variableSummary.hbs
@@ -15,7 +15,8 @@
 				{{#each selectedDatasets}}
 					{{#each variables}}
 					<tr>
-						<td><button title="Remove from processing"><i class="fa fa-times"></i></button></td>
+						<td><button title="Remove from processing" data-id="{{modelId}}" data-variable-id ="{{variableId}}"
+									data-dataset-kind="{{../datasetName}}"><i class="fa fa-times"></i></button></td>
 						<td>{{../datasetName}}</td>
 						<td>{{siteId}}</td>
 						<td>{{startDate}}</td>

--- a/src/main/webapp/js/hb_templates/variableSummary.hbs
+++ b/src/main/webapp/js/hb_templates/variableSummary.hbs
@@ -1,0 +1,30 @@
+<div>
+	{{#if selectedVariables}}
+		<table>
+			<thead>
+				<tr>
+					<th></th>
+					<th>Dataset</th>
+					<th>Site ID</th>
+					<th>Start Date</th>
+					<th>End Date</th>
+					<th>Property</th>
+				</tr>
+			</thead>
+			<tbody>
+				{{#each selectedVariables}}
+					<tr>
+						<td><button title="Remove from processing"><i class="fa fa-times"></i></button></td>
+						<td>{{dataset}}</td>
+						<td>{{siteId}}</td>
+						<td>{{startDate}}</td>
+						<td>{{endDate}}</td>
+						<td>{{property}}</td>
+					</tr>
+				{{/each}}
+			</tbody>
+		</table>
+	{{else}}
+		<div>No variables are currently selected</div>
+	{{/if}}
+</div>

--- a/src/main/webapp/js/hb_templates/variableSummaryRow.hbs
+++ b/src/main/webapp/js/hb_templates/variableSummaryRow.hbs
@@ -1,8 +1,0 @@
-<tr>
-	<td><button title="Remove from processing"><i class="fa fa-times"></i></button></td>
-	<td>{{dataset}}</td>
-	<td>{{siteId}}</td>
-	<td>{{startDate}}</td>
-	<td>{{endDate}}</td>
-	<td>{{property}}</td>
-</tr>

--- a/src/main/webapp/js/hb_templates/variableSummaryRow.hbs
+++ b/src/main/webapp/js/hb_templates/variableSummaryRow.hbs
@@ -1,0 +1,8 @@
+<tr>
+	<td><button title="Remove from processing"><i class="fa fa-times"></i></button></td>
+	<td>{{dataset}}</td>
+	<td>{{siteId}}</td>
+	<td>{{startDate}}</td>
+	<td>{{endDate}}</td>
+	<td>{{property}}</td>
+</tr>

--- a/src/main/webapp/js/models/NWISCollection.js
+++ b/src/main/webapp/js/models/NWISCollection.js
@@ -27,6 +27,13 @@ define([
 			this.sCodePromise = this.getStatisticCodes();
 		},
 
+		/*
+		 * @param {Object with properties west, east, south, north} boundingBox
+		 * @returns {Jquery promise}
+		 *		@resolved with the JqXHR object when the NWIS sites for boundingBox have been fetched, parsed
+		 *			and the collection reset with the new data.
+		 *		@rejected with the jqXHR object if the fetch failed. The collection is cleared.
+		 */
 		fetch: function(boundingBox) {
 			var self = this;
 			var sitesDeferred = $.Deferred();
@@ -130,7 +137,7 @@ define([
 						if (404 === jqXHR.status) {
 							log.debug('No NWIS data available: ' + textStatus);
 							self.reset([]);
-							sitesDeferred.resolve();
+							sitesDeferred.resolve(jqXHR);
 						} else {
 							log.debug('Error in loading NWIS data: ' + textStatus);
 							self.reset([]);
@@ -142,6 +149,10 @@ define([
 			return sitesDeferred.promise();
 		},
 
+		/*
+		 * @returns {Boolean} if any of the nwis sites in the collection have variables that have
+		 * the selected property set to true.
+		 */
 		hasSelectedVariables : function() {
 			var isSelected = function(variableModel) {
 				return variableModel.has('selected') && variableModel.get('selected');

--- a/src/main/webapp/js/models/PrecipitationCollection.js
+++ b/src/main/webapp/js/models/PrecipitationCollection.js
@@ -79,8 +79,13 @@ define([
 			});
 
 			return fetchDeferred.promise();
-		}
+		},
 
+		hasSelectedVariables : function() {
+			return this.some(function(model) {
+				return model.has('selected') && model.get('selected');
+			});
+		}
 	});
 
 	return collection;

--- a/src/main/webapp/js/models/PrecipitationCollection.js
+++ b/src/main/webapp/js/models/PrecipitationCollection.js
@@ -81,6 +81,9 @@ define([
 			return fetchDeferred.promise();
 		},
 
+		/*
+		 * @returns {Boolean} - True if any of the precipitation models contain a selected variable
+		 */
 		hasSelectedVariables : function() {
 			return this.some(function(model) {
 				return model.has('selected') && model.get('selected');

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -11,14 +11,16 @@ define([
 	'views/MapView',
 	'views/LocationView',
 	'views/ChooseView',
+	'views/VariableSummaryView',
 	'hbs!hb_templates/dataDiscovery'
-], function (log, _, Config, $utils, BaseView, NavView, AlertView, MapView, LocationView, ChooseView, hbTemplate) {
+], function (log, _, Config, $utils, BaseView, NavView, AlertView, MapView, LocationView, ChooseView, VariableSummaryView, hbTemplate) {
 	"use strict";
 
 	var NAVVIEW_SELECTOR = '.workflow-nav';
 	var LOCATION_SELECTOR = '.location-panel';
 	var CHOOSE_SELECTOR = '.choose-panel';
 	var MAPVIEW_SELECTOR = '.map-container-div';
+	var VARIABLE_SUMMARY_SELECTOR = '.variable-summary-container';
 	var ALERTVIEW_SELECTOR = '.alert-container';
 	var LOADING_SELECTOR = '.loading-indicator';
 
@@ -75,6 +77,9 @@ define([
 			if (this.chooseView) {
 				this.chooseView.remove();
 			}
+			if (this.variableSummaryView) {
+				this.variableSummaryView.remove();
+			}
 			BaseView.prototype.remove.apply(this, arguments);
 			return this;
 		},
@@ -108,7 +113,12 @@ define([
 						this.chooseView.remove();
 						this.chooseView = undefined;
 					}
+					if (this.variableSummaryView) {
+						this.variableSummaryView.remove();
+						this.variableSummaryView = undefined;
+					}
 					break;
+
 				case Config.CHOOSE_DATA_STEP:
 					if (!this.locationView) {
 						this.locationView = new LocationView({
@@ -133,6 +143,14 @@ define([
 							opened : true
 						});
 						this.chooseView.render();
+					}
+					if (!this.variableSummaryView) {
+						this.variableSummaryView = new VariableSummaryView({
+							el : $utils.createDivInContainer(this.$(VARIABLE_SUMMARY_SELECTOR)),
+							model : model,
+							opened : true
+						});
+						this.variableSummaryView.render();
 					}
 					break;
 			}

--- a/src/main/webapp/js/views/NWISDataView.js
+++ b/src/main/webapp/js/views/NWISDataView.js
@@ -29,34 +29,40 @@ define([
 			BaseCollapsiblePanelView.prototype.initialize.apply(this, arguments);
 
 			this.distanceToProjectLocation = options.distanceToProjectLocation;
+			this.model.get('variables').each(function(variableModel) {
+				this.listenTo(variableModel, 'change:selected', this.updateSelectedCheckbox);
+			}, this);
 		},
 
 		render : function() {
-			var formatDates = function (parameter) {
-				var result = _.clone(parameter);
-				result.startDate = parameter.startDate.format(Config.DATE_FORMAT);
-				result.endDate = parameter.endDate.format(Config.DATE_FORMAT);
+			var formatDates = function (variableModel) {
+				var result = _.clone(variableModel.attributes);
+				result.startDate = variableModel.attributes.startDate.format(Config.DATE_FORMAT);
+				result.endDate = variableModel.attributes.endDate.format(Config.DATE_FORMAT);
+				result.id = variableModel.cid;
 				return result;
 			};
 
 			this.context.name = this.model.get('name');
 			this.context.siteNo = this.model.get('siteNo');
 			this.context.distance = this.distanceToProjectLocation;
-			this.context.parameters = _.map(this.model.get('parameters'), formatDates);
+			this.context.variables = this.model.get('variables').map(formatDates);
+
 			BaseCollapsiblePanelView.prototype.render.apply(this, arguments);
 
 			return this;
 		},
 
 		toggleCollectedDataVariable : function(ev) {
-			var id = $(ev.target).attr('id');
-			var indexToUpdate = id[id.length - 1];
-			var parameters = _.map(this.model.get('parameters'), function(param) {
-				return _.clone(param);
-			});
+			var id = $(ev.target).data('id');
+			var variableModelToUpdate = this.model.get('variables').get(id);
 
-			parameters[indexToUpdate].selected = !parameters[indexToUpdate].selected;
-			this.model.set('parameters', parameters);
+			variableModelToUpdate.set('selected', !variableModelToUpdate.attributes.selected);
+		},
+
+		updateSelectedCheckbox : function(variableModel) {
+			var $checkbox = this.$('input[data-id="' + variableModel.cid + '"]');
+			$checkbox.prop('checked', variableModel.has('selected') && variableModel.get('selected'));
 		}
 
 	});

--- a/src/main/webapp/js/views/NWISDataView.js
+++ b/src/main/webapp/js/views/NWISDataView.js
@@ -51,7 +51,9 @@ define([
 		toggleCollectedDataVariable : function(ev) {
 			var id = $(ev.target).attr('id');
 			var indexToUpdate = id[id.length - 1];
-			var parameters = _.clone(this.model.get('parameters'));
+			var parameters = _.map(this.model.get('parameters'), function(param) {
+				return _.clone(param);
+			});
 
 			parameters[indexToUpdate].selected = !parameters[indexToUpdate].selected;
 			this.model.set('parameters', parameters);

--- a/src/main/webapp/js/views/PrecipDataView.js
+++ b/src/main/webapp/js/views/PrecipDataView.js
@@ -12,7 +12,7 @@ define([
 
 	/* @construct
 	 * @param {Object} options
-	 *		@prop {String jquer selector or jquery element} $el
+	 *		@prop {String jquery selector or jquery element} $el
 	 *		@prop {Backbone.Model representing precipitation grid data} model
 	 *		@prop {String} distanceToProjectLocation
 	 */
@@ -30,6 +30,7 @@ define([
 			BaseCollapsiblePanelView.prototype.initialize.apply(this, arguments);
 
 			this.distanceToProjectLocation = options.distanceToProjectLocation;
+			this.listenTo(this.model, 'change:selected', this.updateSelectedCheckbox);
 		},
 
 		render : function() {
@@ -46,6 +47,10 @@ define([
 
 		toggleCollectedDataVariable : function() {
 			this.model.set('selected', !this.model.get('selected'));
+		},
+
+		updateSelectedCheckbox : function(model) {
+			this.$('table input:checkbox').prop('checked', model.has('selected') && model.get('selected'));
 		}
 	});
 

--- a/src/main/webapp/js/views/VariableSummaryView.js
+++ b/src/main/webapp/js/views/VariableSummaryView.js
@@ -67,7 +67,7 @@ define([
 			var precipCollection = datasetCollections[Config.PRECIP_DATASET];
 			var nwisCollection = datasetCollections[Config.NWIS_DATASET];
 			this.listenTo(precipCollection, 'reset', this.setupPrecipModelListeners);
-			this.listenTo(nwisCollection, 'reset', this.setpNWISModelListeners);
+			this.listenTo(nwisCollection, 'reset', this.setupNWISModelListeners);
 
 			this.setupPrecipModelListeners(precipCollection);
 			this.setupNWISModelListeners(nwisCollection);

--- a/src/main/webapp/js/views/VariableSummaryView.js
+++ b/src/main/webapp/js/views/VariableSummaryView.js
@@ -15,6 +15,10 @@ define([
 		panelHeading : 'Selected Variables',
 		panelBodyId : 'variable-summary-panel-body',
 
+		additionalEvents : {
+			'click button' : 'removeVariable'
+		},
+
 		initialize : function(options) {
 			BaseCollapsiblePanelView.prototype.initialize.apply(this, arguments);
 
@@ -41,9 +45,9 @@ define([
 					variables : values
 				};
 			});
-			this.context.hasSelectedVariables = _.reduce(this.context.selectedDatasets, function(foundVariables, dataset) {
-				return foundVariables || !_.isEmpty(dataset.variables);
-			}, false);
+			this.context.hasSelectedVariables = _.some(this.model.get('datasetCollections'), function(collection) {
+				return collection.hasSelectedVariables();
+			});
 
 			BaseCollapsiblePanelView.prototype.render.apply(this, arguments);
 			return this;
@@ -72,7 +76,10 @@ define([
 
 		initializeNWISCollection : function(collection) {
 			collection.each(function(nwisModel) {
-				this.listenTo(nwisModel, 'change:parameters', this.updateNWISContext);
+				var variableModels = nwisModel.get('variables');
+				variableModels.each(function(variableModel) {
+					this.listenTo(variableModel, 'change:selected', this.updateNWISContext);
+				}, this);
 			}, this);
 			this._updateSelectedNWISVariables(collection);
 
@@ -94,6 +101,8 @@ define([
 			};
 			var getContextVariable = function(model) {
 				return {
+					modelId : model.cid,
+					variableId : model.cid,
 					siteId : (parseFloat(model.attributes.lat)).toFixed(3) + ', ' + (parseFloat(model.attributes.lon)).toFixed(3),
 					startDate : model.attributes.startDate.format(Config.DATE_FORMAT),
 					endDate : model.attributes.endDate.format(Config.DATE_FORMAT),
@@ -116,27 +125,45 @@ define([
 
 		_updateSelectedNWISVariables : function(nwisCollection) {
 			this.selectedDatasets[Config.NWIS_DATASET] = nwisCollection.reduce(function(memo, nwisModel) {
-				var parameters = nwisModel.get('parameters');
+				var variableModels = nwisModel.get('variables');
 
-				var isSelected = function(param) {
-					return _.has(param, 'selected') && param.selected;
+				var isSelected = function(variableModel) {
+					return variableModel.has('selected') && variableModel.get('selected');
 				};
-				var getContextVariable = function(param) {
+				var getContextVariable = function(variableModel) {
 					return {
-						siteId : nwisModel.get('siteNo'),
-						startDate : param.startDate.format(Config.DATE_FORMAT),
-						endDate : param.endDate.format(Config.DATE_FORMAT),
-						property : param.name
+						modelId : nwisModel.cid,
+						variableId : variableModel.cid,
+						siteId : variableModel.attributes.siteNo,
+						startDate : variableModel.attributes.startDate.format(Config.DATE_FORMAT),
+						endDate : variableModel.attributes.endDate.format(Config.DATE_FORMAT),
+						property : variableModel.attributes.name
 					};
 				};
 
-				var selectedParams = _.chain(parameters)
+				var selectedVariables = variableModels.chain()
 					.filter(isSelected)
 				   .map(getContextVariable)
 				   .value();
 
-				return memo.concat(selectedParams);
+				return memo.concat(selectedVariables);
 		   }, []);
+		},
+
+		removeVariable : function(ev) {
+			var $button = $(ev.currentTarget);
+			var id = $button.data('id');
+			var variableId = $button.data('variable-id');
+			var datasetKind = $button.data('dataset-kind');
+			var datasetCollection = this.model.get('datasetCollections')[datasetKind];
+			var datasetModel = datasetCollection.get(id);
+
+			if (id === variableId) {
+				datasetModel.set('selected', false);
+			}
+			else {
+				datasetModel.get('variables').get(variableId).set('selected', false);
+			}
 		}
 	});
 

--- a/src/main/webapp/js/views/VariableSummaryView.js
+++ b/src/main/webapp/js/views/VariableSummaryView.js
@@ -1,0 +1,19 @@
+/* jslint browser: true */
+
+define([
+	'views/BaseCollapsiblePanelView',
+	'hbs!hb_templates/variableSummary'
+], function(BaseCollapsiblePanelView, hbTemplate) {
+	"use strict";
+
+	var view = BaseCollapsiblePanelView.extend({
+		template : hbTemplate,
+
+		panelHeading : 'Selected Variables',
+		panelBodyId : 'variable-summary-panel-body'
+	});
+
+	return view;
+});
+
+

--- a/src/main/webapp/js/views/VariableSummaryView.js
+++ b/src/main/webapp/js/views/VariableSummaryView.js
@@ -1,16 +1,143 @@
 /* jslint browser: true */
+/* global parseFloat */
 
 define([
+	'underscore',
+	'Config',
 	'views/BaseCollapsiblePanelView',
 	'hbs!hb_templates/variableSummary'
-], function(BaseCollapsiblePanelView, hbTemplate) {
+], function(_, Config, BaseCollapsiblePanelView, hbTemplate) {
 	"use strict";
 
 	var view = BaseCollapsiblePanelView.extend({
 		template : hbTemplate,
 
 		panelHeading : 'Selected Variables',
-		panelBodyId : 'variable-summary-panel-body'
+		panelBodyId : 'variable-summary-panel-body',
+
+		initialize : function(options) {
+			BaseCollapsiblePanelView.prototype.initialize.apply(this, arguments);
+
+			this.selectedDatasets = _.object([
+				[Config.PRECIP_DATASET, []],
+				[Config.NWIS_DATASET, []]
+			]);
+			this.hasBeenRendered = false;
+
+			//Set up model event listeners
+			if (this.model.has('datasetCollections')) {
+					this.initializeDatasetCollections(this.model, this.model.get('datasetCollections'));
+				}
+				else {
+					this.listenTo(this.model, 'change:datasetCollections', this.initializeDatasetCollections);
+				}
+		},
+
+		render : function() {
+			this.hasBeenRendered = true;
+			this.context.selectedDatasets = _.map(this.selectedDatasets, function(values, datasetKind) {
+				return {
+					datasetName : datasetKind,
+					variables : values
+				};
+			});
+			this.context.hasSelectedVariables = _.reduce(this.context.selectedDatasets, function(foundVariables, dataset) {
+				return foundVariables || !_.isEmpty(dataset.variables);
+			}, false);
+
+			BaseCollapsiblePanelView.prototype.render.apply(this, arguments);
+			return this;
+		},
+
+		initializeDatasetCollections : function(model, datasetCollections) {
+			var precipCollection = datasetCollections[Config.PRECIP_DATASET];
+			var nwisCollection = datasetCollections[Config.NWIS_DATASET];
+			this.listenTo(precipCollection, 'reset', this.initializePrecipCollection);
+			this.listenTo(nwisCollection, 'reset', this.initializeNWISCollection);
+
+			this.initializePrecipCollection(precipCollection);
+			this.initializeNWISCollection(nwisCollection);
+		},
+
+		initializePrecipCollection : function(collection) {
+			collection.each(function(precipModel) {
+				this.listenTo(precipModel, 'change:selected', this.updatePrecipContext);
+			}, this);
+			this._updateSelectedPrecipPoints(collection);
+
+			if (this.hasBeenRendered) {
+				this.render();
+			}
+		},
+
+		initializeNWISCollection : function(collection) {
+			collection.each(function(nwisModel) {
+				this.listenTo(nwisModel, 'change:parameters', this.updateNWISContext);
+			}, this);
+			this._updateSelectedNWISVariables(collection);
+
+			if (this.hasBeenRendered) {
+				this.render();
+			}
+		},
+
+		updatePrecipContext : function() {
+			this._updateSelectedPrecipPoints(this.model.get('datasetCollections')[Config.PRECIP_DATASET]);
+			if (this.hasBeenRendered) {
+				this.render();
+			}
+		},
+
+		_updateSelectedPrecipPoints : function(precipCollection) {
+			var isSelected = function(model) {
+				return model.has('selected') && model.get('selected');
+			};
+			var getContextVariable = function(model) {
+				return {
+					siteId : (parseFloat(model.attributes.lat)).toFixed(3) + ', ' + (parseFloat(model.attributes.lon)).toFixed(3),
+					startDate : model.attributes.startDate.format(Config.DATE_FORMAT),
+					endDate : model.attributes.endDate.format(Config.DATE_FORMAT),
+					property : model.attributes.y + ':' + model.attributes.x
+				};
+			};
+
+			this.selectedDatasets[Config.PRECIP_DATASET] =  precipCollection.chain()
+				.filter(isSelected)
+				.map(getContextVariable)
+				.value();
+		},
+
+		updateNWISContext : function() {
+			this._updateSelectedNWISVariables(this.model.get('datasetCollections')[Config.NWIS_DATASET]);
+			if (this.hasBeenRendered) {
+				this.render();
+			}
+		},
+
+		_updateSelectedNWISVariables : function(nwisCollection) {
+			this.selectedDatasets[Config.NWIS_DATASET] = nwisCollection.reduce(function(memo, nwisModel) {
+				var parameters = nwisModel.get('parameters');
+
+				var isSelected = function(param) {
+					return _.has(param, 'selected') && param.selected;
+				};
+				var getContextVariable = function(param) {
+					return {
+						siteId : nwisModel.get('siteNo'),
+						startDate : param.startDate.format(Config.DATE_FORMAT),
+						endDate : param.endDate.format(Config.DATE_FORMAT),
+						property : param.name
+					};
+				};
+
+				var selectedParams = _.chain(parameters)
+					.filter(isSelected)
+				   .map(getContextVariable)
+				   .value();
+
+				return memo.concat(selectedParams);
+		   }, []);
+		}
 	});
 
 	return view;

--- a/src/main/webapp/less/custom.less
+++ b/src/main/webapp/less/custom.less
@@ -31,3 +31,4 @@ footer {
 @import "location.less";
 @import "choose.less";
 @import "dataView.less";
+@import "mapOps.less";

--- a/src/main/webapp/less/custom.less
+++ b/src/main/webapp/less/custom.less
@@ -32,3 +32,4 @@ footer {
 @import "choose.less";
 @import "dataView.less";
 @import "mapOps.less";
+@import "variableSummary.less";

--- a/src/main/webapp/less/dataDiscovery.less
+++ b/src/main/webapp/less/dataDiscovery.less
@@ -7,7 +7,7 @@
 	.make-sm-column(9, 0);
 	.make-lg-column(10, 0);
 	
-	#map-div {
+	.map-container-div>div{
 		height: 650px;
 	}
 }

--- a/src/main/webapp/less/dataDiscovery.less
+++ b/src/main/webapp/less/dataDiscovery.less
@@ -8,7 +8,7 @@
 	.make-lg-column(10, 0);
 	
 	.map-container-div>div{
-		height: 650px;
+		height: 500px;
 	}
 }
 .entry-panels-div {

--- a/src/main/webapp/less/mapOps.less
+++ b/src/main/webapp/less/mapOps.less
@@ -1,0 +1,4 @@
+#map-div {
+	height : 100%;
+}
+

--- a/src/main/webapp/less/mapOps.less
+++ b/src/main/webapp/less/mapOps.less
@@ -1,4 +1,8 @@
 #map-div {
 	height : 100%;
 }
+.dataset-variable-container {
+	max-height: 100%;
+	overflow-y: scroll;
+}
 

--- a/src/main/webapp/less/variableSummary.less
+++ b/src/main/webapp/less/variableSummary.less
@@ -1,0 +1,8 @@
+.variable-summary-div {
+	button {
+		color : red;
+		border-style: none;
+		background-color : inherit;
+	}
+}
+

--- a/src/test/js/models/NWISCollectionSpec.js
+++ b/src/test/js/models/NWISCollectionSpec.js
@@ -3,10 +3,11 @@
 
 define([
 	'jquery',
+	'backbone',
 	'models/NWISCollection'
-], function($, NWISCollection) {
+], function($, Backbone, NWISCollection) {
 	describe('models/NWISCollection', function() {
-		var testSiteModel;
+		var testCollection;
 
 		beforeEach(function() {
 			sinon.stub($, "ajax");
@@ -28,6 +29,42 @@ define([
 		it('Expects that an ajax call is made for waterService with the correct url', function() {
 			testCollection.fetch({north : 42.26833, west : -92.426775, south : 42.123607, east : -92.231428});
 			expect($.ajax.calledWithMatch({url: "waterService/?format=rdb&bBox=-92.426775,42.123607,-92.231428,42.268330&outputDataTypeCd=iv,dv&hasDataTypeCd=iv,dv&siteType=OC,LK,ST,SP,AS,AT"}));
+		});
+
+		describe('Tests for hasSelectedVariables', function() {
+			var variables1, variables2, variables3;
+
+			beforeEach(function() {
+				variables1 = new Backbone.Collection([{name : 'V1'}, {name : 'V2'}]);
+				variables2 = new Backbone.Collection([{name : 'V3'}]);
+				variables3 = new Backbone.Collection([{name : 'V4'}, {name : '5'}, {name : '6'}]);
+
+				testCollection.reset([
+					{siteNo : 'S1', variables : variables1},
+					{siteNo : 'S2', variables : variables2},
+					{siteNo : 'S3', variables : variables3}
+				]);
+			});
+
+			it('Expects that if no selected properties are set that false is returned', function() {
+				expect(testCollection.hasSelectedVariables()).toBe(false);
+			});
+
+			it('Expects that if some selected properties are defined but set to false, that false is returned', function() {
+				variables1.at(1).set('selected', false);
+				variables3.at(0).set('selected', false);
+				variables3.at(2).set('selected', false);
+
+				expect(testCollection.hasSelectedVariables()).toBe(false);
+			});
+
+			it('Expects that if one of the selected properties is true, that true is returned', function() {
+				variables1.at(1).set('selected', false);
+				variables3.at(0).set('selected', false);
+				variables3.at(2).set('selected', true);
+
+				expect(testCollection.hasSelectedVariables()).toBe(true);
+			});
 		});
 
 	});

--- a/src/test/js/models/PrecipitationCollectionSpec.js
+++ b/src/test/js/models/PrecipitationCollectionSpec.js
@@ -99,5 +99,32 @@ define([
 				expect(testCollection.at(0).attributes.y).toEqual('557');
 			});
 		});
+
+		describe('Tests for hasSelectedVariables', function() {
+			beforeEach(function() {
+				testCollection.reset([
+					{x : '1', y: '2', lon : '-100', lat : '43.0'},
+					{x : '1', y: '3', lon : '-100', lat : '44.0'},
+					{x : '2', y: '3', lon : '-101', lat : '44.0'}
+				]);
+			});
+
+			it('Expects that if selected is not defined for any of the models that false is returned', function() {
+				expect(testCollection.hasSelectedVariables()).toBe(false);
+			});
+
+			it('Expects that if selected is set to false in one of the models and missing in the others that false is returned', function() {
+				testCollection.at(1).set('selected', false);
+
+				expect(testCollection.hasSelectedVariables()).toBe(false);
+			});
+
+			it('Expects that if selected is set to true in one of the models but false elsewhere that true is returned', function() {
+				testCollection.at(0).set('selected', false);
+				testCollection.at(2).set('selected', true);
+
+				expect(testCollection.hasSelectedVariables()).toBe(true);
+			});
+		});
 	});
 });

--- a/src/test/js/views/DataDiscoveryViewSpec.js
+++ b/src/test/js/views/DataDiscoveryViewSpec.js
@@ -22,6 +22,7 @@ define([
 		var setElMapViewSpy, renderMapViewSpy, removeMapViewSpy;
 		var setElLocationViewSpy, renderLocationViewSpy, removeLocationViewSpy;
 		var setElChooseViewSpy, renderChooseViewSpy, removeChooseViewSpy;
+		var setElSummaryViewSpy, renderSummaryViewSpy, removeSummaryViewSpy;
 		var setElAlertViewSpy, renderAlertViewSpy, removeAlertViewSpy, showSuccessAlertSpy, showDangerAlertSpy, closeAlertSpy;
 
 		var injector;
@@ -50,6 +51,10 @@ define([
 			setElChooseViewSpy = jasmine.createSpy('setElChooseViewSpy');
 			renderChooseViewSpy = jasmine.createSpy('renderChooseViewSpy');
 			removeChooseViewSpy = jasmine.createSpy('removeChooseViewSpy');
+
+			setElSummaryViewSpy = jasmine.createSpy('setElSummaryViewSpy');
+			renderSummaryViewSpy = jasmine.createSpy('renderSummaryViewSpy');
+			removeSummaryViewSpy = jasmine.createSpy('removeSummaryViewSpy');
 
 			setElAlertViewSpy = jasmine.createSpy('setElAlertViewSpy');
 			renderAlertViewSpy = jasmine.createSpy('renderAlertViewSpy');
@@ -93,6 +98,14 @@ define([
 				}),
 				render : renderChooseViewSpy,
 				remove : removeChooseViewSpy
+			}));
+
+			injector.mock('views/VariableSummaryView', BaseView.extend({
+				setElement : setElSummaryViewSpy.and.returnValue({
+					render : renderSummaryViewSpy
+				}),
+				render : renderSummaryViewSpy,
+				remove : removeSummaryViewSpy
 			}));
 
 			injector.mock('views/AlertView', BaseView.extend({
@@ -142,6 +155,7 @@ define([
 			expect(setElMapViewSpy.calls.count()).toBe(0);
 			expect(setElLocationViewSpy.calls.count()).toBe(0);
 			expect(setElChooseViewSpy.calls.count()).toBe(0);
+			expect(setElSummaryViewSpy.calls.count()).toBe(0);
 			expect(setElAlertViewSpy.calls.count()).toBe(1);
 		});
 
@@ -189,9 +203,10 @@ define([
 				expect(setElLocationViewSpy).toHaveBeenCalled();
 				expect(renderLocationViewSpy).toHaveBeenCalled();
 				expect(setElChooseViewSpy).not.toHaveBeenCalled();
+				expect(setElSummaryViewSpy).not.toHaveBeenCalled();
 			});
 
-			it('Expects that if the workflow step is CHOOSE_DATA_STEP, the location, map, and choose data views are created and rendered', function() {
+			it('Expects that if the workflow step is CHOOSE_DATA_STEP, the location, map, variable summary and choose data views are created and rendered', function() {
 				testModel.set('step', Config.CHOOSE_DATA_STEP);
 				testView.render();
 
@@ -201,6 +216,8 @@ define([
 				expect(renderLocationViewSpy).toHaveBeenCalled();
 				expect(setElChooseViewSpy).toHaveBeenCalled();
 				expect(renderChooseViewSpy).toHaveBeenCalled();
+				expect(setElSummaryViewSpy).toHaveBeenCalled();
+				expect(renderSummaryViewSpy).toHaveBeenCalled()
 			});
 		});
 
@@ -223,6 +240,7 @@ define([
 				expect(removeAlertViewSpy).toHaveBeenCalled();
 				expect(removeLocationViewSpy).not.toHaveBeenCalled();
 				expect(removeChooseViewSpy).not.toHaveBeenCalled();
+				expect(removeSummaryViewSpy).not.toHaveBeenCalled();
 				expect(removeMapViewSpy).not.toHaveBeenCalled();
 			});
 
@@ -236,13 +254,14 @@ define([
 				expect(removeMapViewSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that the location,map, and choose data subviews are removed if they have been created', function() {
+			it('Expects that the location,map, variable summary, and choose data subviews are removed if they have been created', function() {
 				testModel.set('step', Config.CHOOSE_DATA_STEP);
 				testView.render();
 				testView.remove();
 
 				expect(removeLocationViewSpy).toHaveBeenCalled();
 				expect(removeChooseViewSpy).toHaveBeenCalled();
+				expect(removeSummaryViewSpy).toHaveBeenCalled();
 				expect(removeMapViewSpy).toHaveBeenCalled();
 			});
 		});
@@ -284,22 +303,28 @@ define([
 			});
 
 
-			it('Expects that if the step changes from CHOOSE_DATA_STEP to PROJ_LOC_STEP, the choose view is removed', function() {
+			it('Expects that if the step changes from CHOOSE_DATA_STEP to PROJ_LOC_STEP, the choose view and summary view is removed', function() {
 				testModel.set('step', Config.CHOOSE_DATA_STEP);
 				removeChooseViewSpy.calls.reset();
+				removeSummaryViewSpy.calls.reset();
 				testModel.set('step', Config.PROJ_LOC_STEP);
 
 				expect(removeChooseViewSpy).toHaveBeenCalled();
+				expect(removeSummaryViewSpy).toHaveBeenCalled()
 			});
 
-			it('Expects that if the step changes from PROJ_LOC_STEP to CHOOSE_DATA_STEP, the choose view is created and rendered', function() {
+			it('Expects that if the step changes from PROJ_LOC_STEP to CHOOSE_DATA_STEP, the choose view and summary views are created and rendered', function() {
 				testModel.set('step', Config.PROJ_LOC_STEP);
 				setElChooseViewSpy.calls.reset();
 				renderChooseViewSpy.calls.reset();
+				setElSummaryViewSpy.calls.reset();
+				renderSummaryViewSpy.calls.reset();
 				testModel.set('step', Config.CHOOSE_DATA_STEP);
 
 				expect(setElChooseViewSpy).toHaveBeenCalled();
 				expect(renderChooseViewSpy).toHaveBeenCalled();
+				expect(setElSummaryViewSpy).toHaveBeenCalled();
+				expect(renderSummaryViewSpy).toHaveBeenCalled();
 			});
 
 			it('Expects that if the step changes, the alert view is closed', function() {

--- a/src/test/js/views/NWISDataViewSpec.js
+++ b/src/test/js/views/NWISDataViewSpec.js
@@ -8,7 +8,7 @@ define([
 	'views/NWISDataView'
 ], function($, moment, Backbone, NWISDataView){
 
-	fdescribe('views/NWISDataView', function() {
+	describe('views/NWISDataView', function() {
 		var testView;
 		var testModel;
 		var $testDiv;

--- a/src/test/js/views/NWISDataViewSpec.js
+++ b/src/test/js/views/NWISDataViewSpec.js
@@ -8,14 +8,32 @@ define([
 	'views/NWISDataView'
 ], function($, moment, Backbone, NWISDataView){
 
-	describe('views/NWISDataView', function() {
+	fdescribe('views/NWISDataView', function() {
 		var testView;
 		var testModel;
 		var $testDiv;
+		var variables;
 
 		beforeEach(function() {
 			$('body').append('<div id="test-div"></div>');
 			$testDiv = $('#test-div');
+
+			variables = new Backbone.Collection([
+				{
+					name : 'Discharge cubic feet per second Daily Mean',
+					parameterCd : '4343',
+					statCd : '1111',
+					startDate : moment('2005-01-01', 'YYYY-MM-DD'),
+					endDate : moment('2015-04-18', 'YYYY-MM-DD')
+				},
+				{
+					name : 'PCode 80155 Daily Mean',
+					parameterCd : '80155',
+					statCd : '1111',
+					startDate : moment('2002-01-01', 'YYYY-MM-DD'),
+					endDate : moment('2016-04-18', 'YYYY-MM-DD')
+				}
+			]);
 
 			testModel = new Backbone.Model({
 				lat : '43.1346',
@@ -24,22 +42,7 @@ define([
 				name : 'PESHTIGO RIVER AT MOUTH NEAR PESHTIGO, WI',
 				startDate : moment('2002-01-01', 'YYYY-MM-DD'),
 				endDate : moment('2016-04-18', 'YYYY-MM-DD'),
-				parameters : [
-					{
-						name : 'Discharge cubic feet per second Daily Mean',
-						parameterCd : '4343',
-						statCd : '1111',
-						startDate : moment('2005-01-01', 'YYYY-MM-DD'),
-						endDate : moment('2015-04-18', 'YYYY-MM-DD')
-					},
-					{
-						name : 'PCode 80155 Daily Mean',
-						parameterCd : '80155',
-						statCd : '1111',
-						startDate : moment('2002-01-01', 'YYYY-MM-DD'),
-						endDate : moment('2016-04-18', 'YYYY-MM-DD')
-					}
-				]
+				variables : variables
 			});
 
 			testView = new NWISDataView({
@@ -60,15 +63,17 @@ define([
 			testView.render();
 
 			expect(testView.context.distance).toEqual('1.344');
-			expect(testView.context.parameters.length).toBe(2);
-			expect(testView.context.parameters[0]).toEqual({
+			expect(testView.context.variables.length).toBe(2);
+			expect(testView.context.variables[0]).toEqual({
+				id : variables.at(0).cid,
 				name : 'Discharge cubic feet per second Daily Mean',
 				parameterCd : '4343',
 				statCd : '1111',
 				startDate : '2005-01-01',
 				endDate : '2015-04-18'
 			});
-			expect(testView.context.parameters[1]).toEqual({
+			expect(testView.context.variables[1]).toEqual({
+				id : variables.at(1).cid,
 				name : 'PCode 80155 Daily Mean',
 				parameterCd : '80155',
 				statCd : '1111',
@@ -78,26 +83,47 @@ define([
 		});
 
 		it('Expects that the checkbox is checked if the selected property for a parameter is set to true when the view is rendered', function() {
-			var parameters = testModel.get('parameters');
-			parameters[0].selected = true;
+			var variables = testModel.get('variables');
+			variables.at(0).set('selected', true);
 			testView.render();
 
-			expect(testModel.get('parameters')[0].selected).toBe(true);
+			expect(testView.context.variables[0].selected).toBe(true);
 		});
 
 		it('Expects that when the checkbox is checked, the selected property is set to true', function() {
+			var var1 = variables.at(1);
 			testView.render();
-			testView.$('#toggle-param1').trigger('click');
+			testView.$('[data-id="' + var1.cid + '"]').trigger('click');
 
-			expect(testModel.get('parameters')[1].selected).toBe(true);
+			expect(var1.get('selected')).toBe(true);
 		});
 
 		it('Expects that when the checkbox is checked and then unchecked, the selected property is set to false', function() {
+			var $checkbox;
+			var var1 = variables.at(1);
 			testView.render();
-			testView.$('#toggle-param1').trigger('click');
-			testView.$('#toggle-param1').trigger('click');
+			$checkbox = testView.$('[data-id="' + var1.cid + '"]');
+			$checkbox.trigger('click');
 
-			expect(testModel.get('parameters')[1].selected).toBe(false);
+			expect(var1.get('selected')).toBe(true);
+
+			$checkbox.trigger('click');
+
+			expect(var1.get('selected')).toBe(false);
+		});
+
+		it('Expects that if a variable model\'s selected attributes changes, the checkbox for that variable reflects the change', function() {
+			var $checkbox;
+			var var1 = variables.at(1);
+			testView.render();
+			$checkbox = testView.$('[data-id="' + var1.cid + '"]');
+			var1.set('selected', true);
+
+			expect($checkbox.prop('checked')).toBe(true);
+
+			var1.set('selected', false);
+
+			expect($checkbox.prop('checked')).toBe(false);
 		});
 	});
 });

--- a/src/test/js/views/PrecipDataViewSpec.js
+++ b/src/test/js/views/PrecipDataViewSpec.js
@@ -39,7 +39,6 @@ define([
 		});
 
 		it('Expects the view to be rendered with a context that contains the formatted contents of the model', function() {
-
 			testView.render();
 
 			expect(testView.context.distance).toEqual('1.345');
@@ -77,6 +76,21 @@ define([
 			testView.$('input:checkbox').trigger('click');
 
 			expect(testModel.get('selected')).toBe(false);
+		});
+
+		it('Expects that if the model\'s selected attribute is updated the variable checkbox reflects it\'s state', function() {
+			var $checkbox;
+			testView.render();
+			$checkbox = testView.$('input:checkbox');
+			testModel.set('selected', false);
+
+			expect($checkbox.prop('checked')).toBe(false);
+
+			testModel.set('selected', true);
+			expect($checkbox.prop('checked')).toBe(true);
+
+			testModel.unset('selected');
+			expect($checkbox.prop('checked')).toBe(false);
 		});
 	});
 });

--- a/src/test/js/views/VariableSummaryViewSpec.js
+++ b/src/test/js/views/VariableSummaryViewSpec.js
@@ -1,0 +1,202 @@
+/* jslint browser: true */
+/* global expect, spyOn */
+
+define([
+	'jquery',
+	'underscore',
+	'backbone',
+	'moment',
+	'Config',
+	'models/WorkflowStateModel',
+	'views/VariableSummaryView'
+], function($, _, Backbone, moment, Config, WorkflowStateModel, VariableSummaryView) {
+	describe('views/VariableSummaryView', function() {
+		var testView;
+		var $testDiv;
+		var testModel;
+
+		beforeEach(function() {
+			$('body').append('<div id="test-div"></div>');
+			$testDiv = $('#test-div');
+
+			testModel = new WorkflowStateModel();
+		});
+
+		afterEach(function() {
+			if (testView) {
+				testView.remove();
+			}
+			$testDiv.remove();
+		});
+
+		describe('Tests for model event listener setup if  the model does not contain any datasets at initialization', function() {
+			beforeEach(function() {
+				testView = new VariableSummaryView({
+					$el : $testDiv,
+					model : testModel
+				});
+				testView.render();
+
+				spyOn(testView, 'render').and.callThrough();
+			});
+
+			it('Expects that when the view is rendered, the context has empty selected datasets', function() {
+
+				expect(testView.context.hasSelectedVariables).toBe(false);
+				_.each(testView.context.selectedDatasets, function(dataset) {
+					expect(dataset.variables.length).toBe(0);
+				});
+			});
+
+			it('Expects that if datasets are added to the workflow model after render, render is called with the expected context', function() {
+				testModel.initializeDatasetCollections();
+
+				expect(testView.render).toHaveBeenCalled();
+				expect(testView.context.hasSelectedVariables).toBe(false);
+				_.each(testView.context.selectedDatasets, function(dataset) {
+					expect(dataset.variables.length).toBe(0);
+				});
+			});
+
+			it('Expects that if data is added to the dataset collections, render is called again', function() {
+				var datasetCollections;
+				testModel.initializeDatasetCollections();
+				datasetCollections = testModel.get('datasetCollections');
+				testView.render.calls.reset();
+				datasetCollections[Config.PRECIP_DATASET].reset([
+					{x : '1', y : '2'}, {x : '2', y : '2'}
+				]);
+				datasetCollections[Config.NWIS_DATASET].reset([
+					{siteId : 'S1', variables : new Backbone.Collection([{name : 'V1'}, {name : 'V2'}])}
+				]);
+
+				expect(testView.render).toHaveBeenCalled();
+				expect(testView.context.hasSelectedVariables).toBe(false);
+				_.each(testView.context.selectedDatasets, function(dataset) {
+					expect(dataset.variables.length).toBe(0);
+				});
+			});
+		});
+
+		describe('Tests for model event listener setup if the model does contain datasets at initialization', function() {
+
+			var datasetCollections;
+			beforeEach(function() {
+				var startDate = moment('2002-04-11', 'YYYY-MM-DD');
+				var endDate = moment('2006-11-23', 'YYYY-MM-DD');
+				testModel.initializeDatasetCollections();
+				datasetCollections = testModel.get('datasetCollections');
+				datasetCollections[Config.PRECIP_DATASET].reset([
+					{x : '1', y : '2', lat : '43', lon : '-90', startDate : startDate, endDate : endDate},
+					{x : '2', y : '3', lat : '44', lon : '-91', startDate : startDate, endDate : endDate}
+				]);
+				datasetCollections[Config.NWIS_DATASET].reset([
+					{siteNo : 'S1', variables : new Backbone.Collection([
+							{name : 'V1', startDate : startDate, endDate : endDate},
+							{name : 'V2', startDate : startDate, endDate : endDate}])}
+				]);
+
+				testView = new VariableSummaryView({
+					$el : $testDiv,
+					model : testModel
+				});
+				testView.render();
+
+				spyOn(testView, 'render').and.callThrough();
+			});
+
+
+			it('Expects that if a precip variable is selected the view is rendered with the appropriate context', function() {
+				var precipSelected;
+				var nwisSelected;
+				var precipModelToUpdate = datasetCollections[Config.PRECIP_DATASET].at(1)
+				precipModelToUpdate.set('selected', true);
+				precipSelected = _.find(testView.context.selectedDatasets, function(d) {
+					return d.datasetName === Config.PRECIP_DATASET;
+				});
+				nwisSelected = _.find(testView.context.selectedDatasets, function(d) {
+					return d.datasetName === Config.NWIS_DATASET;
+				});
+
+				expect(testView.render).toHaveBeenCalled();
+				expect(testView.context.hasSelectedVariables).toBe(true);
+				expect(precipSelected.variables.length).toBe(1);
+				expect(precipSelected.variables[0]).toEqual({
+					modelId : precipModelToUpdate.cid,
+					variableId : precipModelToUpdate.cid,
+					siteId : '44.000, -91.000',
+					startDate : '2002-04-11',
+					endDate : '2006-11-23',
+					property : '3:2'
+				});
+				expect(nwisSelected.variables.length).toBe(0);
+			});
+
+			it('Expects that if a nwis variable is selected the view is rendered with the appropriate context', function() {
+				var precipSelected;
+				var nwisSelected;
+				var nwisModelToUpdate = datasetCollections[Config.NWIS_DATASET].at(0);
+				var nwisVariableToUpdate = nwisModelToUpdate.get('variables').at(1);
+				nwisVariableToUpdate.set('selected', true);
+				precipSelected = _.find(testView.context.selectedDatasets, function(d) {
+					return d.datasetName === Config.PRECIP_DATASET;
+				});
+				nwisSelected = _.find(testView.context.selectedDatasets, function(d) {
+					return d.datasetName === Config.NWIS_DATASET;
+				});
+
+				expect(testView.render).toHaveBeenCalled();
+				expect(testView.context.hasSelectedVariables).toBe(true);
+				expect(precipSelected.variables.length).toBe(0);
+				expect(nwisSelected.variables.length).toBe(1);
+				expect(nwisSelected.variables[0]).toEqual({
+					modelId : nwisModelToUpdate.cid,
+					variableId : nwisVariableToUpdate.cid,
+					siteId : 'S1',
+					startDate : '2002-04-11',
+					endDate : '2006-11-23',
+					property : 'V2'
+				});
+			});
+		});
+
+		describe('Tests for DOM event handlers', function() {
+			var datasetCollections;
+
+			beforeEach(function() {
+				var startDate = moment('2002-04-11', 'YYYY-MM-DD');
+				var endDate = moment('2006-11-23', 'YYYY-MM-DD');
+				testModel.initializeDatasetCollections();
+				datasetCollections = testModel.get('datasetCollections');
+				datasetCollections[Config.PRECIP_DATASET].reset([
+					{x : '1', y : '2', lat : '43', lon : '-90', startDate : startDate, endDate : endDate},
+					{x : '2', y : '3', lat : '44', lon : '-91', startDate : startDate, endDate : endDate, selected: true}
+				]);
+				datasetCollections[Config.NWIS_DATASET].reset([
+					{siteNo : 'S1', variables : new Backbone.Collection([
+							{name : 'V1', startDate : startDate, endDate : endDate, selected : true},
+							{name : 'V2', startDate : startDate, endDate : endDate}])}
+				]);
+
+				testView = new VariableSummaryView({
+					$el : $testDiv,
+					model : testModel
+				});
+				testView.render();
+			});
+
+			it('Expects that clicking a variables remove button unselects that variable', function(){
+				var selectedPrecipModel = datasetCollections[Config.PRECIP_DATASET].at(1);
+				var selectedNWISVariableModel = datasetCollections[Config.NWIS_DATASET].at(0).get('variables').at(0);
+
+				testView.$('button[data-variable-id="' + selectedPrecipModel.cid + '"]').trigger('click');
+
+				expect(selectedPrecipModel.get('selected')).toBe(false);
+
+				testView.$('button[data-variable-id="' + selectedNWISVariableModel.cid + '"]').trigger('click');
+
+				expect(selectedNWISVariableModel.get('selected')).toBe(false);
+			});
+		});
+	});
+});


### PR DESCRIPTION
Added the variable summary view which shows the variables that have been selected for further processing. The variables can be removed from this list by clicking the X in the row containing the variable you wish to remove. Note that in this view, whenever a variable is selected/unselected the entire view is re rendered.

Precipitation grid points have a single variable per site, but NWIS sites can have multiple variables Refactored NWISCollection to store the variables as a collection of models rather than as an array (and changed the name from parameter to variable). This allows the code to put event listeners on the variable model to detect when it is selected/unselected.