### PR TITLE
Enddat 172

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,27 +14,27 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~2.2.1",
-    "requirejs": "~2.1.22",
+    "jquery": "2.2.1",
+    "requirejs": "2.1.22",
     "bootstrap": "https://github.com/twbs/bootstrap.git#3.3.5",
     "text": "requirejs-text#~2.0.14",
-    "underscore": "~1.8.3",
-    "backbone": "~1.2.3",
-    "handlebars": "~4.0.3",
+    "underscore": "1.8.3",
+    "backbone": "1.2.3",
+    "handlebars": "4.0.3",
     "Squire.js": "https://github.com/iammerrick/Squire.js.git#0.2.0",
     "font-awesome": "fontawesome#~4.4.0",
-    "select2": "~4.0.2",
-    "requirejs-hbs": "~0.1.1",
-    "select2-bootstrap-theme": "~0.1.0-beta.4",
-    "leaflet": "^0.7.7",
-    "leaflet-providers": "^1.1.7",
-    "loglevel": "^1.4.0",
-    "backbone.stickit": "^0.9.2",
-    "moment": "^2.12.0",
-    "eonasdan-bootstrap-datetimepicker": "^4.17.37"
+    "select2": "4.0.2",
+    "requirejs-hbs": "0.1.1",
+    "select2-bootstrap-theme": "0.1.0-beta.4",
+    "leaflet": "0.7.7",
+    "leaflet-providers": "1.1.7",
+    "loglevel": "1.4.0",
+    "backbone.stickit": "0.9.2",
+    "moment": "2.12.0",
+    "eonasdan-bootstrap-datetimepicker": "4.17.37"
   },
   "resolutions": {
-    "underscore": "~1.8.3",
-    "jquery": "~2.1.4"
+    "underscore": "1.8.3",
+    "jquery": "2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,16 +13,16 @@
   "author": "OWI",
   "license": "MIT",
   "devDependencies": {
-    "bower": "^1.7.7",
-    "jasmine-core": "^2.4.1",
-    "karma": "^0.13.19",
-    "karma-chrome-launcher": "^0.2.2",
-    "karma-firefox-launcher": "^0.1.7",
-    "karma-jasmine": "^0.3.7",
-    "karma-js-coverage": "^0.4.0",
-    "karma-requirejs": "^0.2.4",
-    "karma-sinon": "^1.0.4",
-    "requirejs": "^2.1.22",
-    "sinon": "^1.17.3"
+    "bower": "1.7.7",
+    "jasmine-core": "2.4.1",
+    "karma": "0.13.19",
+    "karma-chrome-launcher": "0.2.2",
+    "karma-firefox-launcher": "0.1.7",
+    "karma-jasmine": "0.3.7",
+    "karma-js-coverage": "0.4.0",
+    "karma-requirejs": "0.2.4",
+    "karma-sinon": "1.0.4",
+    "requirejs": "2.1.22",
+    "sinon": "1.17.3"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>gov.usgs.owi</groupId>
 	<artifactId>enddat_web</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<name>EnDDaT UI</name>
@@ -118,13 +118,7 @@
 		<dependency>
 			<groupId>gov.usgs.cida</groupId>
 			<artifactId>proxy-utils</artifactId>
-			<version>1.0.7</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>gov.usgs.cida</groupId>
-			<artifactId>tomcat-filters</artifactId>
-			<version>1.0</version>
+			<version>1.0.12</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/webapp/WEB-INF/jsp/head.jsp
+++ b/src/main/webapp/WEB-INF/jsp/head.jsp
@@ -18,9 +18,10 @@
 	Boolean development = Boolean.parseBoolean(props.getProperty("enddat.development"));
 	String baseUrl = props.getProperty("enddat.base.url", request.getContextPath());
 	if (!baseUrl.endsWith("/")) { baseUrl += "/"; }
-	String parameterCodesUrl = props.getProperty("enddat.pmcodes.url");
 	String version = props.getProperty("application.version");
-	String precipWFSGetFeatureUrl = props.getProperty("enddat.precip-wfs-getfeature.url");
+
+	String parameterCodesUrl = props.getProperty("enddat.endpoint.nwis.pmcodes");
+	String precipWFSGetFeatureUrl = props.getProperty("enddat.endpoint.precip.wfsgetfeature");
 %>
 
 <link rel="shortcut icon" type="image/ico" href="img/favicon.ico">

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -19,7 +19,7 @@
 		<servlet-class>gov.usgs.cida.proxy.AlternateProxyServlet</servlet-class>
 		<init-param>
 			<param-name>forward-url-param</param-name>
-			<param-value>enddat.service.url</param-value>
+			<param-value>enddat.endpoint.service</param-value>
 		</init-param>
 		<init-param>
 			<param-name>readTimeout</param-name>
@@ -41,7 +41,7 @@
 		<servlet-class>gov.usgs.cida.proxy.AlternateProxyServlet</servlet-class>
 		<init-param>
 			<param-name>forward-url-param</param-name>
-			<param-value>enddat.waterservice.url</param-value>
+			<param-value>enddat.endpoint.nwis.site</param-value>
 		</init-param>
 		<init-param>
 			<param-name>readTimeout</param-name>
@@ -59,7 +59,7 @@
 		<servlet-class>gov.usgs.cida.proxy.AlternateProxyServlet</servlet-class>
 		<init-param>
 			<param-name>forward-url-param</param-name>
-			<param-value>enddat.statcodes.url</param-value>
+			<param-value>enddat.endpoint.nwis.statcodes</param-value>
 		</init-param>
 		<init-param>
 			<param-name>readTimeout</param-name>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -22,10 +22,6 @@
 			<param-value>enddat.service.url</param-value>
 		</init-param>
 		<init-param>
-			<param-name>forward-url</param-name>
-			<param-value>http://localhost:8080/enddat-services/</param-value>
-		</init-param>
-		<init-param>
 			<param-name>readTimeout</param-name>
 			<param-value>300000</param-value>
 		</init-param>
@@ -60,11 +56,10 @@
 
 	<servlet>
 		<servlet-name>STCodesServlet</servlet-name>
-		<servlet-class>gov.usgs.cida.proxy.AuthIgnoringProxyServlet</servlet-class>
+		<servlet-class>gov.usgs.cida.proxy.AlternateProxyServlet</servlet-class>
 		<init-param>
-			<param-name>forward-url</param-name>
-			<!--<param-value>http://nwis.waterdata.usgs.gov/nwis/help/</param-value>-->
-			<param-value>http://help.waterdata.usgs.gov/code/stat_code_query?fmt=rdb</param-value>
+			<param-name>forward-url-param</param-name>
+			<param-value>enddat.statcodes.url</param-value>
 		</init-param>
 		<init-param>
 			<param-name>readTimeout</param-name>
@@ -74,6 +69,6 @@
 
 	<servlet-mapping>
 		<servlet-name>STCodesServlet</servlet-name>
-		<url-pattern>/stcodes</url-pattern>
+		<url-pattern>/stcodes/*</url-pattern>
 	</servlet-mapping>
 </web-app>

--- a/src/main/webapp/js/models/NWISCollection.js
+++ b/src/main/webapp/js/models/NWISCollection.js
@@ -191,10 +191,10 @@ define([
 				dataType: 'text',
 				success: function(data) {
 					var parsedStats = rdbUtils.parseRDB(data);
-					var statName = _.map(_.pluck(parsedStats, 'stat_NM'), function(nm) {
-						return rdbUtils.toTitleCase(nm);
-					});
-					self.statisticCodes = _.object(_.pluck(parsedStats, 'stat_CD'), statName);
+
+					self.statisticCodes = _.object(
+						_.pluck(parsedStats, 'stat_CD'),
+						_.map(_.pluck(parsedStats, 'stat_NM')), rdbUtils.toTileCase);
 					log.debug('Fetched statistic codes ' + _.size(self.statisticCodes));
 					deferred.resolve();
 				},

--- a/src/main/webapp/js/models/NWISCollection.js
+++ b/src/main/webapp/js/models/NWISCollection.js
@@ -194,7 +194,8 @@ define([
 
 					self.statisticCodes = _.object(
 						_.pluck(parsedStats, 'stat_CD'),
-						_.map(_.pluck(parsedStats, 'stat_NM')), rdbUtils.toTileCase);
+						_.map(_.pluck(parsedStats, 'stat_NM'), rdbUtils.toTitleCase)
+					);
 					log.debug('Fetched statistic codes ' + _.size(self.statisticCodes));
 					deferred.resolve();
 				},

--- a/src/main/webapp/js/models/NWISCollection.js
+++ b/src/main/webapp/js/models/NWISCollection.js
@@ -51,20 +51,7 @@ define([
 					url: self.url,
 					dataType: 'text',
 					success: function(data, textStatus, jqXHR){
-						var lines = data.split("\n");
-						var importantColumns = {
-							"site_no" : null,
-							"station_nm" : null,
-							"dec_lat_va" : null,
-							"dec_long_va" : null,
-							"parm_cd" : null,
-							"stat_cd" : null,
-							"loc_web_ds" : null,
-							"begin_date" : null,
-							"end_date" : null,
-							"count_nu" : null
-						};
-						var parsedSites = rdbUtils.parseRDB(lines, importantColumns);
+						var parsedSites = rdbUtils.parseRDB(data);
 						// Group the parse site information by site id
 						var siteDataBySiteNo = _.groupBy(parsedSites, function(site) {
 							return site.site_no;
@@ -176,18 +163,8 @@ define([
 				url : parameterCodesPath + 'pmcodes?radio_pm_search=param_group&pm_group=Physical&format=rdb&show=parameter_nm',
 				dataType: 'text',
 				success: function(data) {
-					var parsedParams = [];
-					var lines = data.split("\n");
-					var columns = {
-						"parameter_cd" : null,
-						"parameter_nm" : null
-					};
-
-					self.parameterCodes = {};
-					parsedParams = rdbUtils.parseRDB(lines, columns);
-					_.each(parsedParams, function(el, index) {
-						self.parameterCodes[el.parameter_cd] = el.parameter_nm;
-					});
+					var parsedParams = rdbUtils.parseRDB(data);
+					self.parameterCodes = _.object(_.pluck(parsedParams, 'parameter_cd'), _.pluck(parsedParams, 'parameter_nm'))
 					log.debug('Fetched parameter codes ' + _.size(self.parameterCodes));
 					deferred.resolve();
 				},
@@ -210,22 +187,14 @@ define([
 			var deferred = $.Deferred();
 			$.ajax({
 				type : "GET",
-				url : 'stcodes?read_file=stat&format=rdb',
+				url : 'stcodes/?fmt=rdb',
 				dataType: 'text',
 				success: function(data) {
-					var parsedStats = [];
-					var lines = data.split("\n");
-					var columns = {
-						stat_CD : null,
-						stat_NM : null,
-						stat_DS : null
-					};
-
-					self.statisticCodes = {};
-					parsedStats = rdbUtils.parseRDB(lines, columns);
-					_.each(parsedStats, function(el) {
-						self.statisticCodes[el.stat_CD] = rdbUtils.toTitleCase(el.stat_NM);
+					var parsedStats = rdbUtils.parseRDB(data);
+					var statName = _.map(_.pluck(parsedStats, 'stat_NM'), function(nm) {
+						return rdbUtils.toTitleCase(nm);
 					});
+					self.statisticCodes = _.object(_.pluck(parsedStats, 'stat_CD'), statName);
 					log.debug('Fetched statistic codes ' + _.size(self.statisticCodes));
 					deferred.resolve();
 				},

--- a/src/main/webapp/js/utils/rdbUtils.js
+++ b/src/main/webapp/js/utils/rdbUtils.js
@@ -26,6 +26,7 @@ define([
 				return (lineString.length === 0) || lineString[0] === '#';
 			})
 			.map(function(rowString) {
+				// Removes any trailing carriage return and then splits the row into columns
 				if (_.last(rowString) === '\r') {
 					rowString = rowString.substring(0, rowString.length - 2);
 				}
@@ -41,7 +42,7 @@ define([
 	};
 
 	/* @param	{Object} string
-	 * returns	{Object} string - converted string to upper case and remove special characters
+	 * returns	{Object} string - Removes special characters and capitalizes each character which follows a space.
 	 */
 	self.toTitleCase = function (str) {
 		var lowerCase = str.toLowerCase();

--- a/src/test/js/models/PrecipitationCollectionSpec.js
+++ b/src/test/js/models/PrecipitationCollectionSpec.js
@@ -47,7 +47,7 @@ define([
 				expect(fakeServer.requests[0].url).toContain('bbox=' + encodeURIComponent(bbox.south + ',' + bbox.west + ',' + bbox.north + ',' + bbox.east));
 			});
 
-			xit('Expects that failed ajax response causes the promise to be rejected and the collection cleared', function() {
+			it('Expects that failed ajax response causes the promise to be rejected and the collection cleared', function() {
 				fakeServer.respondWith([500, {'Content-Type' : 'text'}, 'Internal server error']);
 				fakeServer.respond();
 				expect(successSpy).not.toHaveBeenCalled();

--- a/src/test/js/models/PrecipitationCollectionSpec.js
+++ b/src/test/js/models/PrecipitationCollectionSpec.js
@@ -47,7 +47,7 @@ define([
 				expect(fakeServer.requests[0].url).toContain('bbox=' + encodeURIComponent(bbox.south + ',' + bbox.west + ',' + bbox.north + ',' + bbox.east));
 			});
 
-			it('Expects that failed ajax response causes the promise to be rejected and the collection cleared', function() {
+			xit('Expects that failed ajax response causes the promise to be rejected and the collection cleared', function() {
 				fakeServer.respondWith([500, {'Content-Type' : 'text'}, 'Internal server error']);
 				fakeServer.respond();
 				expect(successSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
The project was already being compiled with java 8. I wanted to update the proxy-utils to the latest version and try to eliminate use of the AuthIgnoringProxyServlet that we were using to read the NWIS statistic codes service. I was able to do this by modifying the calling parameters slightly and by updating the rdb parsing utility to handle lines that ended in a carriage return and line feed. 

As part of this work I refactored the rdp parsing utility to take the entire file contents as a string, eliminating duplicative code in NWISCollection and by removing the importantColumns parameters, leaving it to the caller of the parsing to modify further than returned array.