### PR TITLE
Enddat 174

### DIFF
--- a/src/main/webapp/js/Config.js
+++ b/src/main/webapp/js/Config.js
@@ -22,7 +22,8 @@ define([], function() {
 		},
 
 		PROJ_LOC_STEP : 'specifyProjectLocation',
-		CHOOSE_DATA_STEP : 'chooseData',
+		CHOOSE_DATA_FILTERS_STEP : 'chooseDataFilters',
+		CHOOSE_DATA_VARIABLES_STEP : 'chooseDataVariables',
 		PROCESS_DATA_STEP :'processData',
 
 		DATE_FORMAT : 'YYYY-MM-DD',

--- a/src/main/webapp/js/controller/AppRouter.js
+++ b/src/main/webapp/js/controller/AppRouter.js
@@ -68,7 +68,7 @@ define([
 				'startDate' : (startDate) ? moment(startDate, DATE_FORMAT) : '',
 				'endDate' : (endDate) ? moment(endDate, DATE_FORMAT) : ''
 			});
-			this.workflowState.set('step', Config.CHOOSE_DATA_STEP);
+			this.workflowState.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 			this.createView(DataDiscoveryView, {
 				model : this.workflowState
 			}).render();

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -137,7 +137,7 @@ define([
 					this.unset('endDate');
 					break;
 
-				case Config.CHOOSE_DATA_STEP:
+				case Config.CHOOSE_DATA_FILTERS_STEP:
 					if (previousStep === Config.PROJ_LOC_STEP) {
 						this.initializeDatasetCollections();
 						this.set('datasets', this.DEFAULT_CHOSEN_DATASETS);

--- a/src/main/webapp/js/views/BaseCollapsiblePanelView.js
+++ b/src/main/webapp/js/views/BaseCollapsiblePanelView.js
@@ -58,6 +58,18 @@ define([
 			return this;
 		},
 
+		collapse : function() {
+			this.$('.panel-body').collapse('hide');
+			this.$('.expand-icon').show();
+			this.$('.collapse-icon').hide();
+		},
+
+		expand : function() {
+			this.$('.panel-body').collapse('show');
+			this.$('.expand-icon').hide();
+			this.$('.collapse-icon').show();
+		},
+
 		toggleIcon : function(ev) {
 			var $button = $(ev.currentTarget);
 			var $visibleIcon = $button.find('i:visible');

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -90,6 +90,8 @@ define([
 		 */
 
 		updateSubViews : function(model, step) {
+			var prevStep = model.previous('step');
+
 			this.alertView.closeAlert();
 			switch(step) {
 				case Config.PROJ_LOC_STEP:
@@ -154,6 +156,13 @@ define([
 						this.variableSummaryView.render();
 					}
 					break;
+
+				case Config.CHOOSE_DATA_VARIABLES_STEP:
+					if (prevStep === Config.CHOOSE_DATA_FILTERS_STEP) {
+						this.locationView.collapse();
+						this.chooseView.collapse();
+					}
+
 			}
 		},
 

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -120,7 +120,7 @@ define([
 					}
 					break;
 
-				case Config.CHOOSE_DATA_STEP:
+				case Config.CHOOSE_DATA_FILTERS_STEP:
 					if (!this.locationView) {
 						this.locationView = new LocationView({
 							el : $utils.createDivInContainer(this.$(LOCATION_SELECTOR)),

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -103,6 +103,9 @@ define([
 						});
 						this.locationView.render();
 					}
+					else {
+						this.locationView.expand();
+					}
 					if (!this.mapView) {
 						this.mapView = new MapView({
 							el : $utils.createDivInContainer(this.$(MAPVIEW_SELECTOR)),

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -86,7 +86,7 @@ define([
 				[L.layerGroup(), L.layerGroup()]
 			);
 
-			this.siteDataViews = {};
+			this.selectedSite = undefined;
 		},
 
 		render : function() {
@@ -138,10 +138,10 @@ define([
 		},
 
 		removeDataViews : function() {
-			_.each(this.siteDataViews, function(view) {
-				view.remove();
-			});
-			this.siteDataViews = {};
+			if (this.selectedSite) {
+				this.selectedSite.dataView.remove();
+				this.selectedSite = undefined;
+			}
 		},
 
 		/*
@@ -289,19 +289,23 @@ define([
 				var projectLocation = L.latLng(self.model.attributes.location.latitude, self.model.attributes.location.longitude);
 
 				self.removeDataViews();
-				self.siteDataViews[datasetKind] = new DataViews[datasetKind]({
-					el : $utils.createDivInContainer(self.$(VARIABLE_CONTAINER_SEL)),
-					distanceToProjectLocation : LUtils.milesBetween(projectLocation, siteLatLng).toFixed(3),
+				self.selectedSite = {
+					datasetKind : datasetKind,
 					model : siteModel,
-					opened : true
-				});
+					dataView : new DataViews[datasetKind]({
+						el : $utils.createDivInContainer(self.$(VARIABLE_CONTAINER_SEL)),
+						distanceToProjectLocation : LUtils.milesBetween(projectLocation, siteLatLng).toFixed(3),
+						model : siteModel,
+						opened : true
+					})
+				};
 
 				if (!$mapDiv.hasClass(MAP_WIDTH_CLASS)) {
 					$mapDiv.addClass(MAP_WIDTH_CLASS);
 					self.map.invalidateSize();
 					self.$(VARIABLE_CONTAINER_SEL).addClass(DATA_VIEW_WIDTH_CLASS);
 				}
-				self.siteDataViews[datasetKind].render();
+				self.selectedSite.dataView.render();
 			};
 
 			this.siteLayerGroups[datasetKind].clearLayers();

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -330,6 +330,7 @@ define([
 				marker.on('click', function(ev) {
 					moveCircleMarker(latLng);
 					updateDataView(siteModel, latLng);
+					self.model.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
 				});
 			});
 		},

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -207,7 +207,7 @@ define([
 					}
 					break;
 
-				case Config.CHOOSE_DATA_STEP:
+				case Config.CHOOSE_DATA_FILTERS_STEP:
 					this.legendControl.setVisibility(true);
 					break;
 			}

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -32,6 +32,7 @@ define([
 			this.navSelector = {};
 			this.navSelector[Config.PROJ_LOC_STEP] = '.nav-project-loc';
 			this.navSelector[Config.CHOOSE_DATA_FILTERS_STEP] = '.nav-choose-data';
+			this.navSelector[Config.CHOOSE_DATA_VARIABLES_STEP] = '.nav-choose-data';
 			this.navSelector[Config.PROCESS_DATA_STEP] = '.nav-process-data';
 
 			this.listenTo(this.model, 'change', this.updateNavigation);

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -31,7 +31,7 @@ define([
 
 			this.navSelector = {};
 			this.navSelector[Config.PROJ_LOC_STEP] = '.nav-project-loc';
-			this.navSelector[Config.CHOOSE_DATA_STEP] = '.nav-choose-data';
+			this.navSelector[Config.CHOOSE_DATA_FILTERS_STEP] = '.nav-choose-data';
 			this.navSelector[Config.PROCESS_DATA_STEP] = '.nav-process-data';
 
 			this.listenTo(this.model, 'change', this.updateNavigation);
@@ -62,9 +62,10 @@ define([
 			}
 		},
 		goToChooseDataStep : function(ev) {
+			var step = this.model.get('step');
 			ev.preventDefault();
-			if (this.model.get('step') !== Config.CHOOSE_DATA_STEP) {
-				this.model.set('step', Config.CHOOSE_DATA_STEP);
+			if ((step !== Config.CHOOSE_DATA_FILTERS_STEP) && (step !== Config.CHOOSE_DATA_VARIABLES_STEP)) {
+				this.model.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 			}
 		},
 		goToProcessDataStep : function(ev) {
@@ -101,7 +102,7 @@ define([
 			switch(newStep) {
 				case Config.PROJ_LOC_STEP:
 					var location = model.get('location');
-					$chooseDataBtn = this.$(this.navSelector[Config.CHOOSE_DATA_STEP]);
+					$chooseDataBtn = this.$(this.navSelector[Config.CHOOSE_DATA_FILTERS_STEP]);
 					$processDataBtn = this.$(this.navSelector[Config.PROCESS_DATA_STEP]);
 
 					if ((location) && _.has(location, 'latitude') && (location.latitude) &&
@@ -116,7 +117,7 @@ define([
 					this.router.navigate('');
 					break;
 
-				case Config.CHOOSE_DATA_STEP:
+				case Config.CHOOSE_DATA_FILTERS_STEP:
 					$processDataBtn = this.$(this.navSelector[Config.PROCESS_DATA_STEP]);
 					//TODO: We will need to add code to remove the disabled class from the process Data button
 					// when we know what will allow that step.

--- a/src/test/js/models/WorkflowStateModelSpec.js
+++ b/src/test/js/models/WorkflowStateModelSpec.js
@@ -204,21 +204,21 @@ define([
 				expect(resetPrecipSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that if the step changes to CHOOSE_DATA_STEP and the previous step was PROJ_LOC_STEP that the default radius and chosen datasets are set', function() {
+			it('Expects that if the step changes to CHOOSE_DATA_FILTERS_STEP and the previous step was PROJ_LOC_STEP that the default radius and chosen datasets are set', function() {
 				testModel.set('step', Config.PROJ_LOC_STEP);
 				testModel.set('location', {latitude : '43.0', longitude : '-100.0'});
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 
 				expect(testModel.get('radius')).toEqual(testModel.DEFAULT_CHOOSE_DATA_RADIUS);
 				expect(testModel.get('datasets')).toEqual(testModel.DEFAULT_CHOSEN_DATASETS);
 			});
 
-			it('Expects that if the step changes to CHOOSE_DATA_STEP and the previous step was PROJ_LOC_STEP, the chosen datasets are fetched', function() {
+			it('Expects that if the step changes to CHOOSE_DATA_FILTERS_STEP and the previous step was PROJ_LOC_STEP, the chosen datasets are fetched', function() {
 				testModel.set('step', Config.PROJ_LOC_STEP);
 				testModel.set('location', {latitude : '43.0', longitude : '-100.0'});
 				fetchPrecipSpy.calls.reset();
 				fetchSiteSpy.calls.reset();
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 
 				expect(fetchPrecipSpy).not.toHaveBeenCalled();
 				expect(fetchSiteSpy).toHaveBeenCalled();

--- a/src/test/js/views/BaseCollapsiblePanelViewSpec.js
+++ b/src/test/js/views/BaseCollapsiblePanelViewSpec.js
@@ -104,6 +104,44 @@ define([
 			});
 		});
 
+		describe('Tests for collapse function', function() {
+			it('Expects that if the panel is open and the collapse function is called, the panel is collapsed', function() {
+				testView = new TestPanelView({
+					el : $testDiv,
+					context : {
+						buttonName : 'Test Button Name'
+					},
+					opened : true
+				});
+				testView.render();
+				testView.collapse();
+
+				expect($testDiv.find('.collapse-icon').is(':visible')).toBe(false);
+				expect($testDiv.find('.expand-icon').is(':visible')).toBe(true);
+				expect($testDiv.find('.panel-body').hasClass('in')).toBe(false);
+			});
+		});
+
+		describe('Tests for expand function', function() {
+			it('Expects that if the panel is closed and the expand function is called, the panel is opened', function() {
+				testView = new TestPanelView({
+					el : $testDiv,
+					context : {
+						buttonName : 'Test Button Name'
+					},
+					opened : false
+				});
+				testView.render();
+				testView.expand();
+
+				expect($testDiv.find('.collapse-icon').is(':visible')).toBe(true);
+				expect($testDiv.find('.expand-icon').is(':visible')).toBe(false);
+				setTimeout(function() {
+					expect($testDiv.find('.panel-body').hasClass('in')).toBe(true);
+				}, 1000);
+			});
+		});
+
 		describe('Tests for toggling the collapse icon', function() {
 			var $toggle, $collapseBtn, $expandBtn;
 			beforeEach(function() {

--- a/src/test/js/views/DataDiscoveryViewSpec.js
+++ b/src/test/js/views/DataDiscoveryViewSpec.js
@@ -21,8 +21,8 @@ define([
 		var initializeBaseViewSpy, renderBaseViewSpy, removeBaseViewSpy;
 		var setElNavViewSpy, renderNavViewSpy, removeNavViewSpy;
 		var setElMapViewSpy, renderMapViewSpy, removeMapViewSpy;
-		var setElLocationViewSpy, renderLocationViewSpy, removeLocationViewSpy;
-		var setElChooseViewSpy, renderChooseViewSpy, removeChooseViewSpy;
+		var setElLocationViewSpy, renderLocationViewSpy, removeLocationViewSpy, collapseLocationViewSpy, expandLocationViewSpy;
+		var setElChooseViewSpy, renderChooseViewSpy, removeChooseViewSpy, collapseChooseViewSpy, expandChooseViewSpy;
 		var setElSummaryViewSpy, renderSummaryViewSpy, removeSummaryViewSpy;
 		var setElAlertViewSpy, renderAlertViewSpy, removeAlertViewSpy, showSuccessAlertSpy, showDangerAlertSpy, closeAlertSpy;
 
@@ -48,10 +48,15 @@ define([
 			setElLocationViewSpy = jasmine.createSpy('setElLocationViewSpy');
 			renderLocationViewSpy = jasmine.createSpy('renderLocationViewSpy');
 			removeLocationViewSpy = jasmine.createSpy('removeLocationViewSpy');
+			collapseLocationViewSpy = jasmine.createSpy('collapseLocationViewSpy');
+			expandLocationViewSpy = jasmine.createSpy('expandLocationViewSpy');
 
 			setElChooseViewSpy = jasmine.createSpy('setElChooseViewSpy');
 			renderChooseViewSpy = jasmine.createSpy('renderChooseViewSpy');
 			removeChooseViewSpy = jasmine.createSpy('removeChooseViewSpy');
+			collapseChooseViewSpy = jasmine.createSpy('collapseChooseViewSpy');
+			expandChooseViewSpy = jasmine.createSpy('expandChooseViewSpy');
+
 
 			setElSummaryViewSpy = jasmine.createSpy('setElSummaryViewSpy');
 			renderSummaryViewSpy = jasmine.createSpy('renderSummaryViewSpy');
@@ -90,7 +95,9 @@ define([
 					render : renderLocationViewSpy
 				}),
 				render : renderLocationViewSpy,
-				remove : removeLocationViewSpy
+				remove : removeLocationViewSpy,
+				expand : expandLocationViewSpy,
+				collapse : collapseLocationViewSpy
 			}));
 
 			injector.mock('views/ChooseView', BaseView.extend({
@@ -98,7 +105,9 @@ define([
 					render : renderChooseViewSpy
 				}),
 				render : renderChooseViewSpy,
-				remove : removeChooseViewSpy
+				remove : removeChooseViewSpy,
+				expand : expandChooseViewSpy,
+				collapse : collapseChooseViewSpy
 			}));
 
 			injector.mock('views/VariableSummaryView', BaseView.extend({
@@ -317,7 +326,7 @@ define([
 				expect(showSuccessAlertSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to PROJ_LOC_STEP, the choose view and summary view is removed', function() {
+			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to PROJ_LOC_STEP, the choose view and summary view are removed and the location view is expanded', function() {
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				removeChooseViewSpy.calls.reset();
 				removeSummaryViewSpy.calls.reset();
@@ -325,6 +334,7 @@ define([
 
 				expect(removeChooseViewSpy).toHaveBeenCalled();
 				expect(removeSummaryViewSpy).toHaveBeenCalled();
+				expect(expandLocationViewSpy).toHaveBeenCalled();
 			});
 
 			it('Expects that if the step changes from PROJ_LOC_STEP to CHOOSE_DATA_FILTERS_STEP, the choose view and summary views are created and rendered', function() {
@@ -339,6 +349,16 @@ define([
 				expect(renderChooseViewSpy).toHaveBeenCalled();
 				expect(setElSummaryViewSpy).toHaveBeenCalled();
 				expect(renderSummaryViewSpy).toHaveBeenCalled();
+			});
+
+			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to CHOOSE_DATA_VARIABLE_STEP, the location and choose views are collapsed', function() {
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				collapseLocationViewSpy.calls.reset();
+				collapseChooseViewSpy.calls.reset();
+				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
+
+				expect(collapseLocationViewSpy).toHaveBeenCalled();
+				expect(collapseChooseViewSpy).toHaveBeenCalled();
 			});
 
 			it('Expects that if the step changes, the alert view is closed', function() {

--- a/src/test/js/views/DataDiscoveryViewSpec.js
+++ b/src/test/js/views/DataDiscoveryViewSpec.js
@@ -207,8 +207,8 @@ define([
 				expect(setElSummaryViewSpy).not.toHaveBeenCalled();
 			});
 
-			it('Expects that if the workflow step is CHOOSE_DATA_STEP, the location, map, variable summary and choose data views are created and rendered', function() {
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+			it('Expects that if the workflow step is CHOOSE_DATA_FILTERS_STEP, the location, map, variable summary and choose data views are created and rendered', function() {
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				testView.render();
 
 				expect(setElMapViewSpy).toHaveBeenCalled();
@@ -256,7 +256,7 @@ define([
 			});
 
 			it('Expects that the location,map, variable summary, and choose data subviews are removed if they have been created', function() {
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				testView.render();
 				testView.remove();
 
@@ -317,8 +317,8 @@ define([
 				expect(showSuccessAlertSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that if the step changes from CHOOSE_DATA_STEP to PROJ_LOC_STEP, the choose view and summary view is removed', function() {
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to PROJ_LOC_STEP, the choose view and summary view is removed', function() {
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				removeChooseViewSpy.calls.reset();
 				removeSummaryViewSpy.calls.reset();
 				testModel.set('step', Config.PROJ_LOC_STEP);
@@ -327,13 +327,13 @@ define([
 				expect(removeSummaryViewSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that if the step changes from PROJ_LOC_STEP to CHOOSE_DATA_STEP, the choose view and summary views are created and rendered', function() {
+			it('Expects that if the step changes from PROJ_LOC_STEP to CHOOSE_DATA_FILTERS_STEP, the choose view and summary views are created and rendered', function() {
 				testModel.set('step', Config.PROJ_LOC_STEP);
 				setElChooseViewSpy.calls.reset();
 				renderChooseViewSpy.calls.reset();
 				setElSummaryViewSpy.calls.reset();
 				renderSummaryViewSpy.calls.reset();
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 
 				expect(setElChooseViewSpy).toHaveBeenCalled();
 				expect(renderChooseViewSpy).toHaveBeenCalled();
@@ -343,7 +343,7 @@ define([
 
 			it('Expects that if the step changes, the alert view is closed', function() {
 				closeAlertSpy.calls.reset();
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 
 				expect(closeAlertSpy).toHaveBeenCalled();
 			});

--- a/src/test/js/views/MapViewSpec.js
+++ b/src/test/js/views/MapViewSpec.js
@@ -205,21 +205,18 @@ define([
 				expect(removeMapSpy).toHaveBeenCalled();
 			});
 
-			it('Expects siteDataViews to be removed ', function() {
-				var nwisRemoveSpy = jasmine.createSpy('nwisRemoveSpy');
-				var precipRemoveSpy = jasmine.createSpy('precipRemoveSpy');
-				testView.siteDataViews[Config.NWIS_DATASET] = {
-					remove : nwisRemoveSpy
-				};
-				testView.siteDataViews[Config.PRECIP_DATASET] = {
-					remove : precipRemoveSpy
+			it('Expects selectedSite\'s data view to be removed ', function() {
+				var dataViewRemoveSpy = jasmine.createSpy('nwisRemoveSpy');
+				testView.selectedSite = {
+					dataView : {
+						remove : dataViewRemoveSpy
+					}
 				};
 				testView.render();
 				testView.remove();
 
-				expect(nwisRemoveSpy).toHaveBeenCalled();
-				expect(precipRemoveSpy).toHaveBeenCalled();
-				expect(testView.siteDataViews).toEqual({});
+				expect(dataViewRemoveSpy).toHaveBeenCalled();
+				expect(testView.selectedSite).not.toBeDefined();
 			});
 		});
 
@@ -229,20 +226,17 @@ define([
 			});
 
 			it('Expects that if the testModel changes the step to PROJ_LOC_STEP, that the dataViews are removed and assigned undefined', function() {
-				var removePrecipSpy = jasmine.createSpy('removePrecipSpy');
-				var removeNWISSpy = jasmine.createSpy('removeNWISSpy');
-				testView.siteataViews = {};
-				testView.siteDataViews[Config.PRECIP_DATASET] = {
-					remove : removePrecipSpy
+				var dataViewRemoveSpy = jasmine.createSpy('nwisRemoveSpy');
+				testView.selectedSite = {
+					dataView : {
+						remove : dataViewRemoveSpy
+					}
 				};
-				testView.siteDataViews[Config.NWIS_DATASET] = {
-					remove : removeNWISSpy
-				};
+
 				testModel.set('step', Config.PROJ_LOC_STEP);
 
-				expect(removePrecipSpy).toHaveBeenCalled();
-				expect(removeNWISSpy).toHaveBeenCalled();
-				expect(testView.precipDataView).toBeUndefined();
+				expect(dataViewRemoveSpy).toHaveBeenCalled();
+				expect(testView.selectedSite).toBeUndefined();
 			});
 
 			it('Expects that if location goes from unset to set the marker is added to the map and it\'s location is set', function() {

--- a/src/test/js/views/NavViewSpec.js
+++ b/src/test/js/views/NavViewSpec.js
@@ -122,7 +122,7 @@ define([
 				});
 			});
 
-			it('Expects that clicking the choose data button, changes the step to choose data', function() {
+			it('Expects that clicking the choose data button, changes the step to CHOOSE_DATA_FILTERS_STEP', function() {
 				testModel.set({
 					step : Config.PROJ_LOC_STEP,
 					location : {latitude : 43.0, longitude : -100.0}
@@ -263,6 +263,19 @@ define([
 				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/43/lng/-100/radius/2/startdate/1Jan2000/enddate/1Jan2010/dataset/NWIS/Precip']);
 				testModel.set('radius', 10);
 				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/43/lng/-100/radius/10/startdate/1Jan2000/enddate/1Jan2010/dataset/NWIS/Precip']);
+			});
+
+			it('Expects that if the step is CHOOSE_DATA_FILTERS_STEP and changed to CHOOSE_DATA_VARIABLES_STEP, the choose data btn remains active', function() {
+				testModel.set('location', {latitude: 43.0, longitude : -100.0});
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
+
+				expect(testView.$(projLocSel + ' a').hasClass('active')).toBe(false);
+				expect(testView.$(chooseDataSel + ' a').hasClass('active')).toBe(true);
+				expect(testView.$(processDataSel + ' a').hasClass('active')).toBe(false);
+				expect(testView.$(projLocSel).hasClass('disabled')).toBe(false);
+				expect(testView.$(chooseDataSel).hasClass('disabled')).toBe(false);
+				expect(testView.$(processDataSel).hasClass('disabled')).toBe(true);
 			});
 		});
 	});

--- a/src/test/js/views/NavViewSpec.js
+++ b/src/test/js/views/NavViewSpec.js
@@ -98,9 +98,9 @@ define([
 				expect(testView.$(processDataSel).hasClass('disabled')).toBe(true);
 			});
 
-			it('Expects that if the workflow step is CHOOSE_DATA_STEP the choose data btn is active and the process data step is disabled', function() {
+			it('Expects that if the workflow step is CHOOSE_DATA_FILTERS_STEP the choose data btn is active and the process data step is disabled', function() {
 				testModel.set({
-					step : Config.CHOOSE_DATA_STEP,
+					step : Config.CHOOSE_DATA_FILTERS_STEP,
 					location : {latitude : 43.0, longitude : -100.0}
 				});
 				testView.render();
@@ -130,12 +130,28 @@ define([
 				testView.render();
 				$(chooseDataSel + ' a').trigger('click');
 
-				expect(testModel.get('step')).toEqual(Config.CHOOSE_DATA_STEP);
+				expect(testModel.get('step')).toEqual(Config.CHOOSE_DATA_FILTERS_STEP);
+			});
+
+			it('Expects that clicking the choose data button, only changes the step if the current step is not CHOOSE_DATA_FILTERS_STEP or CHOOSE_DATA_VARIABLES_STEP', function() {
+				testModel.set({
+					step : Config.CHOOSE_DATA_FILTERS_STEP,
+					location : {latitude : 43.0, longitude : -100.0}
+				});
+				testView.render();
+				$(chooseDataSel + ' a').trigger('click');
+
+				expect(testModel.get('step')).toEqual(Config.CHOOSE_DATA_FILTERS_STEP);
+
+				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
+				$(chooseDataSel + ' a').trigger('click');
+
+				expect(testModel.get('step')).toEqual(Config.CHOOSE_DATA_VARIABLES_STEP);
 			});
 
 			it('Expects that clicking the project location button causes the warning modal to be shown', function() {
 				testModel.set({
-					step : Config.CHOOSE_DATA_STEP,
+					step : Config.CHOOSE_DATA_FILTERS_STEP,
 					location : {latitude : 43.0, longitude : -100.0}
 				});
 				testView.render();
@@ -148,7 +164,7 @@ define([
 			it('Expects that clicking the cancel button in the modal does nothing to the state of the workflow model', function() {
 				var currentWorkflowState;
 				testModel.set({
-					step : Config.CHOOSE_DATA_STEP,
+					step : Config.CHOOSE_DATA_FILTERS_STEP,
 					location : {latitude : 43.0, longitude : -100.0}
 				});
 				currentWorkflowState = testModel.attributes;
@@ -162,7 +178,7 @@ define([
 			it('Expects that clicking the ok button sets the workflow step to PROJ_LOC_STEP', function() {
 				var currentWorkflowState;
 				testModel.set({
-					step : Config.CHOOSE_DATA_STEP,
+					step : Config.CHOOSE_DATA_FILTERS_STEP,
 					location : {latitude : 43.0, longitude : -100.0}
 				});
 				currentWorkflowState = testModel.attributes;
@@ -191,9 +207,9 @@ define([
 				expect(testView.$(processDataSel).hasClass('disabled')).toBe(true);
 			});
 
-			it('Expects that if the step is changed to CHOOSE_DATA, the choose data btn is active', function() {
+			it('Expects that if the step is changed to CHOOSE_DATA_FILTERS_STEP, the choose data btn is active', function() {
 				testModel.set('location', {latitude: 43.0, longitude : -100.0});
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				expect(testView.$(projLocSel + ' a').hasClass('active')).toBe(false);
 				expect(testView.$(chooseDataSel + ' a').hasClass('active')).toBe(true);
 				expect(testView.$(processDataSel + ' a').hasClass('active')).toBe(false);
@@ -202,8 +218,8 @@ define([
 				expect(testView.$(processDataSel).hasClass('disabled')).toBe(true);
 			});
 
-			it('Expects that if the step is changed to CHOOSE_DATA, then the router will navigate to the url with the lat and lon in it', function() {
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+			it('Expects that if the step is changed to CHOOSE_DATA_FILTERS_STEP, then the router will navigate to the url with the lat and lon in it', function() {
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				testModel.set({
 					location : {latitude: 42.0, longitude : -101.0},
 					radius : '',
@@ -212,8 +228,8 @@ define([
 				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/42/lng/-101/dataset/']);
 			});
 
-			it('Expects that if the step is CHOOSE_DATA and the location becomes invalid that the url is not updated', function() {
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+			it('Expects that if the step is CHOOSE_DATA_FILTERS_STEP and the location becomes invalid that the url is not updated', function() {
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				testModel.set({
 					location : {latitude: 42.0, longitude : -101.0},
 					radius : '',
@@ -228,9 +244,9 @@ define([
 				expect(mockRouter.navigate).not.toHaveBeenCalled();
 			});
 
-			it('Expects that if the step is CHOOSE_DATA and radius, location, start/endDate, and datasets change the router will navigate to the appropriate url', function() {
+			it('Expects that if the step is CHOOSE_DATA_FILTERS_STEP and radius, location, start/endDate, and datasets change the router will navigate to the appropriate url', function() {
 				testModel.set('location', {latitude: 43.0, longitude : -100.0});
-				testModel.set('step', Config.CHOOSE_DATA_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				testModel.set({
 					radius : 2,
 					datasets : ['NWIS']


### PR DESCRIPTION
Refactored MapView to make it clear that only one dataView is visible. Created a view level property, selectedSite which contains the datasetKind, selected model and dataView. Use this when updating the site markers to see if the selectedModel is still in the filtered site collection. If not, the data view and circle marker are removed.

To add the feature to collapse the project location and choose data panes when a user starts clicking on sites, split the CHOOSE_DATA_STEP into CHOOSE_DATA_FILTERS_STEP and CHOOSE_DATA_VARIABLES_STEP. In the normal workflow, the application goes into the CHOOSE_DATA_FILTERS_STEP when the Choose Data button is clicked. When the user starts selecting sites on the map, the step is changed to CHOOSE_DATA_VARIABLES_STEP and this triggers collapsing of the location and choose data views.  