### PR TITLE
Enddat 194

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/head.jsp
+++ b/src/main/webapp/WEB-INF/jsp/head.jsp
@@ -22,7 +22,7 @@
 
 	String parameterCodesUrl = props.getProperty("enddat.endpoint.nwis.pmcodes");
 	String precipWFSGetFeatureUrl = props.getProperty("enddat.endpoint.precip.wfsgetfeature");
-	String servicesUrl = props.getProperty("enddat.endpoint.service");
+	String cidaThreddsPrecipData = props.getProperty("enddat.cidathredds.precipdata");
 %>
 
 <link rel="shortcut icon" type="image/ico" href="img/favicon.ico">

--- a/src/main/webapp/WEB-INF/jsp/head.jsp
+++ b/src/main/webapp/WEB-INF/jsp/head.jsp
@@ -22,6 +22,7 @@
 
 	String parameterCodesUrl = props.getProperty("enddat.endpoint.nwis.pmcodes");
 	String precipWFSGetFeatureUrl = props.getProperty("enddat.endpoint.precip.wfsgetfeature");
+	String servicesUrl = props.getProperty("enddat.endpoint.service");
 %>
 
 <link rel="shortcut icon" type="image/ico" href="img/favicon.ico">

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -71,4 +71,22 @@
 		<servlet-name>STCodesServlet</servlet-name>
 		<url-pattern>/stcodes/*</url-pattern>
 	</servlet-mapping>
+	
+	<servlet>
+		<servlet-name>CidaThreddsServlet</servlet-name>
+		<servlet-class>gov.usgs.cida.proxy.AlternateProxyServlet</servlet-class>
+		<init-param>
+			<param-name>forward-url-param</param-name>
+			<param-value>enddat.endpoint.cidathredds</param-value>
+		</init-param>
+		<init-param>
+			<param-name>readTimeout</param-name>
+			<param-value>300000</param-value>
+		</init-param>	
+	</servlet>
+	
+	<servlet-mapping>
+		<servlet-name>CidaThreddsServlet</servlet-name>
+		<url-pattern>/cidathredds/*</url-pattern>
+	</servlet-mapping>
 </web-app>

--- a/src/main/webapp/dataDiscovery.jsp
+++ b/src/main/webapp/dataDiscovery.jsp
@@ -34,8 +34,10 @@
 						'parameterCodesPath': '<%=parameterCodesUrl%>'
 				 	},
 					'models/PrecipitationCollection' : {
-						'precipWFSGetFeatureUrl' : '<%=precipWFSGetFeatureUrl%>',
-					}
+						'precipWFSGetFeatureUrl' : '<%=precipWFSGetFeatureUrl%>'
+					},
+					'models/WorkflowStateModel' : {
+						'serviceUrl' : '<%=servicesUrl%>'
 				},
 				baseUrl: "<%=baseUrl%>/js/",
 				paths: {

--- a/src/main/webapp/dataDiscovery.jsp
+++ b/src/main/webapp/dataDiscovery.jsp
@@ -38,6 +38,7 @@
 					},
 					'models/WorkflowStateModel' : {
 						'serviceUrl' : '<%=servicesUrl%>'
+					}
 				},
 				baseUrl: "<%=baseUrl%>/js/",
 				paths: {

--- a/src/main/webapp/dataDiscovery.jsp
+++ b/src/main/webapp/dataDiscovery.jsp
@@ -34,7 +34,8 @@
 						'parameterCodesPath': '<%=parameterCodesUrl%>'
 				 	},
 					'models/PrecipitationCollection' : {
-						'precipWFSGetFeatureUrl' : '<%=precipWFSGetFeatureUrl%>'
+						'precipWFSGetFeatureUrl' : '<%=precipWFSGetFeatureUrl%>',
+						'cidaThreddsPrecipData' : '<%=cidaThreddsPrecipData%>'
 					},
 					'views/ProcessDataView' : {
 						'baseUrl' : '<%=baseUrl%>'

--- a/src/main/webapp/dataDiscovery.jsp
+++ b/src/main/webapp/dataDiscovery.jsp
@@ -36,8 +36,8 @@
 					'models/PrecipitationCollection' : {
 						'precipWFSGetFeatureUrl' : '<%=precipWFSGetFeatureUrl%>'
 					},
-					'models/WorkflowStateModel' : {
-						'serviceUrl' : '<%=servicesUrl%>'
+					'views/ProcessDataView' : {
+						'baseUrl' : '<%=baseUrl%>'
 					}
 				},
 				baseUrl: "<%=baseUrl%>/js/",

--- a/src/main/webapp/js/hb_templates/dataDiscovery.hbs
+++ b/src/main/webapp/js/hb_templates/dataDiscovery.hbs
@@ -10,5 +10,6 @@
 	</div>
 	<div class="map-container-div"></div>
 	<div class="variable-summary-container"></div>
+	<div class="process-data-container"></div>
 </div>
 	

--- a/src/main/webapp/js/hb_templates/processData.hbs
+++ b/src/main/webapp/js/hb_templates/processData.hbs
@@ -1,0 +1,5 @@
+<div class ="op-buttons-container">
+	<button class="btn btn-info show-url-btn" type="button">Show data processing url</button>
+	<button class="btn btn-primary get-data-btn" type="button">Get data (opens new tab)</button>
+</div>
+<div class="url-container"></div>

--- a/src/main/webapp/js/hb_templates/processData.hbs
+++ b/src/main/webapp/js/hb_templates/processData.hbs
@@ -1,5 +1,9 @@
-<div class ="op-buttons-container">
-	<button class="btn btn-info show-url-btn" type="button">Show data processing url</button>
-	<button class="btn btn-primary get-data-btn" type="button">Get data (opens new tab)</button>
-</div>
-<div class="url-container"></div>
+{{#if hasOverlappingData }}
+	<div class ="op-buttons-container">
+		<button class="btn btn-info show-url-btn" type="button">Show data processing url</button>
+		<button class="btn btn-primary get-data-btn" type="button">Get data (opens new tab)</button>
+	</div>
+	<div class="url-container"></div>
+{{else}}
+	<div class="error-warning">Unable to process data because there are no overlapping times in selected variables.</div>
+{{/if}}

--- a/src/main/webapp/js/models/BaseDatasetCollection.js
+++ b/src/main/webapp/js/models/BaseDatasetCollection.js
@@ -2,9 +2,10 @@
 
 define([
 	'underscore',
+	'moment',
 	'backbone',
 	'utils/dateUtils'
-], function(_, Backbone, dateUtils) {
+], function(_, moment, Backbone, dateUtils) {
 
 	/*
 	 * @constructs - the collection contains models with startDate and endDate properties, both moment objects and a
@@ -58,6 +59,26 @@ define([
 				return siteModel.get('variables').getSelectedUrlParams(siteModel.attributes);
 			});
 			return _.flatten(params);
+		},
+
+		getSelectedOverlappingDateRange : function() {
+			var result = undefined;
+			var siteSelectedVarsDateRange =
+				_.chain(this.models)
+					.map(function(siteModel) {
+						return siteModel.get('variables').getSelectedOverlappingDateRange();
+					})
+					.filter(function(dateRange) {
+						return (dateRange);
+					})
+					.value();
+			if (siteSelectedVarsDateRange.length !== 0) {
+				result = {
+					start : moment.max(_.pluck(siteSelectedVarsDateRange, 'start')),
+					end : moment.min(_.pluck(siteSelectedVarsDateRange, 'end'))
+				};
+			}
+			return result;
 		}
 	});
 

--- a/src/main/webapp/js/models/BaseDatasetCollection.js
+++ b/src/main/webapp/js/models/BaseDatasetCollection.js
@@ -13,6 +13,15 @@ define([
 	var collection = Backbone.Collection.extend({
 
 		/*
+		 * @returns {Boolean} - ture if any of the models contain a variable that has been selected
+		 */
+		hasSelectedVariables : function() {
+			return this.some(function(model) {
+				return model.get('variables').hasSelectedVariables();
+			});
+		},
+
+		/*
 		 * The startDate and endDate values in each model are assumed to be moment objects
 		 * @param {Moment} startDate
 		 * @param {Moment} endDate

--- a/src/main/webapp/js/models/BaseDatasetCollection.js
+++ b/src/main/webapp/js/models/BaseDatasetCollection.js
@@ -19,7 +19,7 @@ define([
 		 * @returns {Array of Backbone.Model} whose startDate and endDate range overlaps the function parameters.
 		 *		If startDate or endDate are falsy, all of the models in the collection are returned.
 		 */
-		getModelsWithinDateFilter : function(startDate, endDate) {
+		getSiteModelsWithinDateFilter : function(startDate, endDate) {
 			var dateFilter;
 			var result;
 
@@ -29,11 +29,7 @@ define([
 					end : endDate
 				};
 				result = this.filter(function(model) {
-					var modelDateRange = {
-						start : model.get('startDate'),
-						end : model.get('endDate')
-					};
-					return dateUtils.dateRangeOverlaps(modelDateRange, dateFilter);
+					return dateUtils.dateRangeOverlaps(model.attributes.variables.getDateRange(), dateFilter);
 				});
 			}
 			else {

--- a/src/main/webapp/js/models/BaseDatasetCollection.js
+++ b/src/main/webapp/js/models/BaseDatasetCollection.js
@@ -6,7 +6,7 @@ define([
 	'backbone',
 	'utils/dateUtils'
 ], function(_, moment, Backbone, dateUtils) {
-
+	"use strict";
 	/*
 	 * @constructs - the collection contains models with startDate and endDate properties, both moment objects and a
 	 * variables property which is BaseVariableCollection.
@@ -63,16 +63,16 @@ define([
 
 		getSelectedOverlappingDateRange : function() {
 			var result = undefined;
-			var siteSelectedVarsDateRange =
-				_.chain(this.models)
-					.map(function(siteModel) {
-						return siteModel.get('variables').getSelectedOverlappingDateRange();
-					})
-					.filter(function(dateRange) {
-						return (dateRange);
-					})
-					.value();
-			if (siteSelectedVarsDateRange.length !== 0) {
+			var siteSelectedVarsDateRange = this.chain()
+				.filter(function(siteModel) {
+					return siteModel.get('variables').hasSelectedVariables();
+				})
+				.map(function(siteModel) {
+					return siteModel.get('variables').getSelectedOverlappingDateRange();
+				})
+				.value();
+
+			if ((siteSelectedVarsDateRange.length > 0) && !_.contains(siteSelectedVarsDateRange, undefined)) {
 				result = {
 					start : moment.max(_.pluck(siteSelectedVarsDateRange, 'start')),
 					end : moment.min(_.pluck(siteSelectedVarsDateRange, 'end'))

--- a/src/main/webapp/js/models/BaseDatasetCollection.js
+++ b/src/main/webapp/js/models/BaseDatasetCollection.js
@@ -53,12 +53,11 @@ define([
 		 *		 representing the URL parameters for the selected variables
 		 */
 		getSelectedVariablesUrlParams : function() {
-			var variablesCollections = this.pluck('variables');
-			var getSelectedUrlParams = function(variableCollection) {
-				return variableCollection.selectedUrlParams();
-			};
-
-			return _.flatten(_.map(variablesCollections, getSelectedUrlParams));
+			var params = [];
+			params = this.map(function(siteModel)  {
+				return siteModel.get('variables').getSelectedUrlParams(siteModel.attributes);
+			});
+			return _.flatten(params);
 		}
 	});
 

--- a/src/main/webapp/js/models/BaseDatasetCollection.js
+++ b/src/main/webapp/js/models/BaseDatasetCollection.js
@@ -6,8 +6,11 @@ define([
 	'utils/dateUtils'
 ], function(_, Backbone, dateUtils) {
 
-	var model = Backbone.Collection.extend({
-
+	/*
+	 * @constructs - the collection contains models with startDate and endDate properties, both moment objects and a
+	 * variables property which is BaseVariableCollection.
+	 */
+	var collection = Backbone.Collection.extend({
 
 		/*
 		 * The startDate and endDate values in each model are assumed to be moment objects
@@ -38,10 +41,23 @@ define([
 			}
 
 			return result;
+		},
+
+		/*
+		 * @returns {Array of Objects with name and value properties} -
+		 *		 representing the URL parameters for the selected variables
+		 */
+		getSelectedVariablesUrlParams : function() {
+			var variablesCollections = this.pluck('variables');
+			var getSelectedUrlParams = function(variableCollection) {
+				return variableCollection.selectedUrlParams();
+			};
+
+			return _.flatten(_.map(variablesCollections, getSelectedUrlParams));
 		}
 	});
 
-	return model;
+	return collection;
 });
 
 

--- a/src/main/webapp/js/models/BaseVariableCollection.js
+++ b/src/main/webapp/js/models/BaseVariableCollection.js
@@ -14,14 +14,6 @@ define([
 	var collection = Backbone.Collection.extend({
 
 		/*
-		 * Should be overridden when this collection is extended
-		 * @returns {Array of Objects with name and value properties representing URL parameters}
-		 */
-		selectedUrlParams : function() {
-			return [];
-		},
-
-		/*
 		 * @returns {Boolean} - true if any model in the collection has the selected property set to true.
 		 */
 		hasSelectedVariables : function() {

--- a/src/main/webapp/js/models/BaseVariableCollection.js
+++ b/src/main/webapp/js/models/BaseVariableCollection.js
@@ -6,7 +6,7 @@ define([
 	'moment',
 	'utils/dateUtils'
 ], function(_, Backbone, moment, dateUtils) {
-
+	"use strict";
 	/*
 	 * Models are xpected to have startDate and endDate property and to use the selected property to indicate that
 	 * this model has been chosen (for further processing)

--- a/src/main/webapp/js/models/BaseVariableCollection.js
+++ b/src/main/webapp/js/models/BaseVariableCollection.js
@@ -38,6 +38,21 @@ define([
 				return model.has('selected') && model.get('selected');
 			});
 		},
+		/*
+		 * @returns {Object} - with start and end properties.
+		 * returns the range of dates where at least one variable in the collection has data. If the
+		 * collection contains no variables, return undefined.
+		 */
+		getDateRange : function() {
+			var dateRange = undefined;
+			if (this.length !== 0) {
+				dateRange = {
+					start : moment.min(this.pluck('startDate')),
+					end : moment.max(this.pluck('endDate'))
+				};
+			}
+			return dateRange;
+		},
 
 		/*
 		 * @returns {Object} - with start and end properties.

--- a/src/main/webapp/js/models/BaseVariableCollection.js
+++ b/src/main/webapp/js/models/BaseVariableCollection.js
@@ -13,6 +13,17 @@ define([
 	 */
 	var collection = Backbone.Collection.extend({
 
+		/*
+		 * Should be overridden when this collection is extended
+		 * @returns {Array of Objects with name and value properties representing URL parameters}
+		 */
+		selectedUrlParams : function() {
+			return [];
+		},
+
+		/*
+		 * @returns {Boolean} - true if any model in the collection has the selected property set to true.
+		 */
 		hasSelectedVariables : function() {
 			return this.some(function(model) {
 				return model.has('selected') && model.get('selected');

--- a/src/main/webapp/js/models/BaseVariableCollection.js
+++ b/src/main/webapp/js/models/BaseVariableCollection.js
@@ -1,0 +1,72 @@
+/* jslint browser: true */
+
+define([
+	'underscore',
+	'backbone',
+	'moment',
+	'utils/dateUtils'
+], function(_, Backbone, moment, dateUtils) {
+
+	/*
+	 * Models are xpected to have startDate and endDate property and to use the selected property to indicate that
+	 * this model has been chosen (for further processing)
+	 */
+	var collection = Backbone.Collection.extend({
+
+		hasSelectedVariables : function() {
+			return this.some(function(model) {
+				return model.has('selected') && model.get('selected');
+			});
+		},
+
+		/*
+		 * @returns {Array of models} where selected is set to true.
+		 */
+		getSelectedVariables : function() {
+			return this.filter(function(model) {
+				return model.has('selected') && model.get('selected');
+			});
+		},
+
+		/*
+		 * @returns {Object} - with start and end properties.
+		 * returns the range of dates where each variable in the collection has data. If no such range
+		 * return undefined.
+		 */
+		getOverlappingDateRange : function() {
+			var dateRange = undefined;
+			if (this.length !== 0) {
+				dateRange = {
+					start : moment.max(this.pluck('startDate')),
+					end : moment.min(this.pluck('endDate'))
+				};
+				if (dateRange.start.isAfter(dateRange.end)) {
+					dateRange = undefined;
+				}
+			}
+			return dateRange;
+		},
+
+		/*
+		 * @returns {Object} - with start and end properties.
+		 * returns the range of dates where each variable in the collection has data. If no such range
+		 * return undefined.
+		 */
+		getSelectedOverlappingDateRange : function() {
+			var selectedVars = this.getSelectedVariables();
+			var dateRange = undefined;
+			if (selectedVars.length !== 0) {
+				dateRange = {
+					start : moment.max(_.map(selectedVars, function(model) { return model.get('startDate'); })),
+					end : moment.min(_.map(selectedVars, function(model) { return model.get('endDate'); }))
+				};
+				if (dateRange.start.isAfter(dateRange.end)) {
+					dateRange = undefined;
+				}
+			}
+			return dateRange;
+		}
+	});
+
+	return collection;
+});

--- a/src/main/webapp/js/models/NWISCollection.js
+++ b/src/main/webapp/js/models/NWISCollection.js
@@ -84,8 +84,9 @@ define([
 								else {
 									name += ' ' + statCd;
 								}
-
+								// We are putting the siteNo in the variables collection as it is needed when forming url parameters
 								return {
+									siteNo : variable.site_no,
 									name : name,
 									parameterCd : variable.parm_cd,
 									statCd : statCd,
@@ -134,24 +135,6 @@ define([
 				});
 			});
 			return sitesDeferred.promise();
-		},
-
-		/*
-		 * @returns {Boolean} if any of the nwis sites in the collection have variables that have
-		 * the selected property set to true.
-		 */
-		hasSelectedVariables : function() {
-			var isSelected = function(variableModel) {
-				return variableModel.has('selected') && variableModel.get('selected');
-			};
-			return this.some(function(model) {
-				return model.has('variables') && model.get('variables').some(isSelected);
-			});
-
-		},
-
-		getSelectedVariableDateRange : function() {
-			var selectedModels;
 		},
 
 		/*

--- a/src/main/webapp/js/models/NWISCollection.js
+++ b/src/main/webapp/js/models/NWISCollection.js
@@ -86,7 +86,6 @@ define([
 								}
 								// We are putting the siteNo in the variables collection as it is needed when forming url parameters
 								return {
-									siteNo : variable.site_no,
 									name : name,
 									parameterCd : variable.parm_cd,
 									statCd : statCd,

--- a/src/main/webapp/js/models/NWISCollection.js
+++ b/src/main/webapp/js/models/NWISCollection.js
@@ -135,7 +135,7 @@ define([
 			});
 			return sitesDeferred.promise();
 		},
-
+		
 		/*
 		 * Retrieves the parameter codes and set the parameterCodes property on the collection. If
 		 * the fetch fails the parameterCodes property is assigned undefined.

--- a/src/main/webapp/js/models/NWISCollection.js
+++ b/src/main/webapp/js/models/NWISCollection.js
@@ -4,12 +4,12 @@ define([
 	'jquery',
 	'underscore',
 	'moment',
-	'backbone',
 	'loglevel',
 	'module',
 	'models/BaseDatasetCollection',
+	'models/NWISVariableCollection',
 	'utils/rdbUtils'
-], function ($, _, moment, Backbone, log, module, BaseDatasetCollection, rdbUtils) {
+], function ($, _, moment, log, module, BaseDatasetCollection, NWISVariableCollection, rdbUtils) {
 	"use strict";
 
 	var parameterCodesPath = module.config().parameterCodesPath;
@@ -111,7 +111,7 @@ define([
 								lon : siteParameterData[0].dec_long_va,
 								startDate : moment.min(startDates),
 								endDate : moment.max(endDates),
-								variables : new Backbone.Collection(variables)
+								variables : new NWISVariableCollection(variables)
 							};
 							return result;
 						});

--- a/src/main/webapp/js/models/NWISCollection.js
+++ b/src/main/webapp/js/models/NWISCollection.js
@@ -150,6 +150,10 @@ define([
 
 		},
 
+		getSelectedVariableDateRange : function() {
+			var selectedModels;
+		},
+
 		/*
 		 * Retrieves the parameter codes and set the parameterCodes property on the collection. If
 		 * the fetch fails the parameterCodes property is assigned undefined.

--- a/src/main/webapp/js/models/NWISVariableCollection.js
+++ b/src/main/webapp/js/models/NWISVariableCollection.js
@@ -8,15 +8,15 @@ define([
 
 	var collection = BaseVariableCollection.extend({
 
-		selectedUrlParams : function(siteNo) {
+		getSelectedUrlParams : function(siteAttributes) {
 			var selectedVars = this.getSelectedVariables();
 
 			return _.map(selectedVars, function(model) {
-				var attrs = model.attributes;
+				var varAttrs = model.attributes;
 				return {
 					name : 'NWIS',
-					value : siteNo + ':' + attrs.parameterCd + ':' + attrs.statCd +
-						'!' + attrs.name + ': ' + siteNo
+					value : siteAttributes.siteNo + ':' + varAttrs.parameterCd + ':' + varAttrs.statCd +
+						'!' + varAttrs.name + ': ' + siteAttributes.siteNo
 				};
 			});
 		}

--- a/src/main/webapp/js/models/NWISVariableCollection.js
+++ b/src/main/webapp/js/models/NWISVariableCollection.js
@@ -5,25 +5,18 @@ define([
 	'models/BaseVariableCollection'
 ], function(_, BaseVariableCollection) {
 
-	var TIME_BOUNDS = 124860;
-	var variableId = 'precip3';
-	var variableName = 'Total precip - 1 hr';
 
-	/*
-	 * @constructs
-	 * models contain properties for x, y, startDate, endDate, and optional selected
-	 */
 	var collection = BaseVariableCollection.extend({
 
 		selectedUrlParams : function() {
 			var selectedVars = this.getSelectedVariables();
+
 			return _.map(selectedVars, function(model) {
 				var attrs = model.attributes;
 				return {
-					name : 'Precip',
-					value : attrs.y + ':' + attrs.x + ':' +
-						TIME_BOUNDS + ':' + variableId + '!' + variableName +
-						' [' + attrs.y + ',' + attrs.x + ']'
+					name : 'NWIS',
+					value : attrs.siteNo + ':' + attrs.parameterCd + ':' + attrs.statCd +
+						'!' + attrs.name + ': ' + attrs.siteNo
 				};
 			});
 		}
@@ -31,4 +24,5 @@ define([
 
 	return collection;
 });
+
 

--- a/src/main/webapp/js/models/NWISVariableCollection.js
+++ b/src/main/webapp/js/models/NWISVariableCollection.js
@@ -8,15 +8,15 @@ define([
 
 	var collection = BaseVariableCollection.extend({
 
-		selectedUrlParams : function() {
+		selectedUrlParams : function(siteNo) {
 			var selectedVars = this.getSelectedVariables();
 
 			return _.map(selectedVars, function(model) {
 				var attrs = model.attributes;
 				return {
 					name : 'NWIS',
-					value : attrs.siteNo + ':' + attrs.parameterCd + ':' + attrs.statCd +
-						'!' + attrs.name + ': ' + attrs.siteNo
+					value : siteNo + ':' + attrs.parameterCd + ':' + attrs.statCd +
+						'!' + attrs.name + ': ' + siteNo
 				};
 			});
 		}

--- a/src/main/webapp/js/models/NWISVariableCollection.js
+++ b/src/main/webapp/js/models/NWISVariableCollection.js
@@ -4,7 +4,7 @@ define([
 	'underscore',
 	'models/BaseVariableCollection'
 ], function(_, BaseVariableCollection) {
-
+	"use strict";
 
 	var collection = BaseVariableCollection.extend({
 

--- a/src/main/webapp/js/models/PrecipitationCollection.js
+++ b/src/main/webapp/js/models/PrecipitationCollection.js
@@ -86,18 +86,7 @@ define([
 			});
 
 			return fetchDeferred.promise();
-		},
-
-		/*
-		 * @returns {Boolean} - True if any of the precipitation models contain a selected variable
-		 */
-		hasSelectedVariables : function() {
-			return this.some(function(model) {
-				return model.has('selected') && model.get('selected');
-			});
-		},
-
-
+		}
 	});
 
 	return collection;

--- a/src/main/webapp/js/models/PrecipitationCollection.js
+++ b/src/main/webapp/js/models/PrecipitationCollection.js
@@ -6,8 +6,9 @@ define([
 	'jquery',
 	'moment',
 	'models/BaseDatasetCollection',
+	'models/PrecipitationVariableCollection',
 	'utils/jqueryUtils'
-], function(log, module, $, moment, BaseDatasetCollection, $utils) {
+], function(log, module, $, moment, BaseDatasetCollection, PrecipitationVariableCollection, $utils) {
 	"use strict";
 
 	var getInteger = function(str) {
@@ -21,7 +22,9 @@ define([
 		url : module.config().precipWFSGetFeatureUrl,
 
 		/*
-		 * Parse the {Document} and returns a json object which can be used to create the collection.
+		 * Parse the xml document and returns a json object which can be used to create the collection.
+		 * Each precipitation site represents a single variable so the variables property will
+		 * contain a collection with a single model.
 		 * @param {Document} xml
 		 * @returns {Array of Objects}
 		 */
@@ -32,12 +35,16 @@ define([
 				var $this = $(this);
 
 				result.push({
-					x : getInteger($utils.xmlFind($this, 'sb', 'x').text()),
-					y : getInteger($utils.xmlFind($this, 'sb', 'y').text()),
 					lon : $utils.xmlFind($this, 'sb', 'X1').text(),
 					lat : $utils.xmlFind($this, 'sb', 'X2').text(),
-					startDate : START_DATE,
-					endDate : today
+					variables : new PrecipitationVariableCollection([
+						{
+							x : getInteger($utils.xmlFind($this, 'sb', 'x').text()),
+							y : getInteger($utils.xmlFind($this, 'sb', 'y').text()),
+							startDate : START_DATE,
+							endDate : today
+						}
+					])
 				});
 			});
 			return result;
@@ -88,7 +95,9 @@ define([
 			return this.some(function(model) {
 				return model.has('selected') && model.get('selected');
 			});
-		}
+		},
+
+
 	});
 
 	return collection;

--- a/src/main/webapp/js/models/PrecipitationVariableCollection.js
+++ b/src/main/webapp/js/models/PrecipitationVariableCollection.js
@@ -4,6 +4,7 @@ define([
 	'underscore',
 	'models/BaseVariableCollection'
 ], function(_, BaseVariableCollection) {
+	"use strict";
 
 	var variableId = 'precip3';
 	var variableName = 'Total precip - 1 hr';

--- a/src/main/webapp/js/models/PrecipitationVariableCollection.js
+++ b/src/main/webapp/js/models/PrecipitationVariableCollection.js
@@ -5,7 +5,6 @@ define([
 	'models/BaseVariableCollection'
 ], function(_, BaseVariableCollection) {
 
-	var TIME_BOUNDS = 124860;
 	var variableId = 'precip3';
 	var variableName = 'Total precip - 1 hr';
 
@@ -15,14 +14,14 @@ define([
 	 */
 	var collection = BaseVariableCollection.extend({
 
-		getSelectedUrlParams : function() {
+		getSelectedUrlParams : function(timeBounds) {
 			var selectedVars = this.getSelectedVariables();
 			return _.map(selectedVars, function(model) {
 				var attrs = model.attributes;
 				return {
 					name : 'Precip',
 					value : attrs.y + ':' + attrs.x + ':' +
-						TIME_BOUNDS + ':' + variableId + '!' + variableName +
+						timeBounds + ':' + variableId + '!' + variableName +
 						' [' + attrs.y + ',' + attrs.x + ']'
 				};
 			});

--- a/src/main/webapp/js/models/PrecipitationVariableCollection.js
+++ b/src/main/webapp/js/models/PrecipitationVariableCollection.js
@@ -1,0 +1,33 @@
+/* jslint browser: true */
+
+define([
+	'models/BaseVariableCollection'
+], function(BaseVariableCollection) {
+
+	var TIME_BOUNDS = 124860;
+	var variableId = 'precip3';
+	var variableName = 'Total precip - 1 hr'
+
+	/*
+	 * @constructs
+	 * models contain properties for x, y, startDate, endDate, and optional selected
+	 */
+	var collection = BaseVariableCollection.extend({
+
+		selectedUrlParams : function() {
+			var selectedVars = this.getSelectedVariables();
+			return _.map(selectedVars, function(model) {
+				var attrs = model.attributes;
+				return {
+					name : 'Precip',
+					value : attrs.y + ':' + attrs.x + ':' +
+						TIME_BOUNDS + ':' + variableId + '!' + variableName +
+						' [' + attrs.y + ',' + attrs.x + ']'
+				};
+			});
+		}
+	});
+
+	return collection;
+});
+

--- a/src/main/webapp/js/models/PrecipitationVariableCollection.js
+++ b/src/main/webapp/js/models/PrecipitationVariableCollection.js
@@ -15,7 +15,7 @@ define([
 	 */
 	var collection = BaseVariableCollection.extend({
 
-		selectedUrlParams : function() {
+		getSelectedUrlParams : function() {
 			var selectedVars = this.getSelectedVariables();
 			return _.map(selectedVars, function(model) {
 				var attrs = model.attributes;

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -26,7 +26,8 @@ define([
 
 		defaults : function() {
 			return {
-				step : 'unknown'
+				step : 'unknown',
+				hasSelectedVariables : false
 			};
 		},
 
@@ -175,6 +176,12 @@ define([
 				var donePromise = $.Deferred();
 				datasetCollection.fetch(boundingBox)
 					.done(function() {
+						/* set up event handlers to update hasSelectedVariables */
+						datasetCollection.each(function(siteModel) {
+							siteModel.get('variables').each(function(variableModel) {
+								variableModel.on('change:selected', self.updateHasSelectedVariables, self);
+							});
+						});
 						donePromise.resolve();
 					})
 					.fail(function() {
@@ -209,8 +216,14 @@ define([
 			});
 		},
 
-		getProcessingUrl : function() {
-			var params;
+		/*
+		 * Event handler for dataset collection variables selected change handler.
+		 */
+		updateHasSelectedVariables : function() {
+			var hasSelectedVariables = _.some(this.get('datasetCollections'), function(datasetCollection) {
+				return datasetCollection.hasSelectedVariables();
+			});
+			this.set('hasSelectedVariables', hasSelectedVariables);
 		}
 	});
 

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -11,9 +11,18 @@ define([
 ], function(_, $, Backbone, Config, geoSpatialUtils, NWISCollection, PrecipitationCollection) {
 	"use strict";
 
+	var DEFAULT_CHOOSE_DATA_RADIUS = 2;
+	var DEFAULT_CHOSEN_DATASETS = ['NWIS'];
+
+	// Defaults for processing step
+	var DEFAULT_TIME_INTERVAL = 6
+	var DEFAULT_TIME_ZONE = '0_GMT'
+	var DEFAULT_PROCESSING_TIME_RANGE_FROM_LATEST = 30; // Days after the latest selected variable's data.
+	var DEFAULT_OUTPUT_DATA_FORMAT = 'Excel';
+	var DEFAULT_OUTPUT_FORMAT = 'tab';
+
 	var model = Backbone.Model.extend({
-		DEFAULT_CHOOSE_DATA_RADIUS : 2,
-		DEFAULT_CHOSEN_DATASETS : ['NWIS'],
+
 
 		defaults : function() {
 			return {
@@ -140,10 +149,15 @@ define([
 				case Config.CHOOSE_DATA_FILTERS_STEP:
 					if (previousStep === Config.PROJ_LOC_STEP) {
 						this.initializeDatasetCollections();
-						this.set('datasets', this.DEFAULT_CHOSEN_DATASETS);
-						this.set('radius', this.DEFAULT_CHOOSE_DATA_RADIUS);
+						this.set('datasets', DEFAULT_CHOSEN_DATASETS);
+						this.set('radius', DEFAULT_CHOOSE_DATA_RADIUS);
 					}
 					break;
+
+				case Config.PROCESS_DATA_STEP:
+					this.set('processParams', {
+
+					});
 			}
 		},
 
@@ -193,6 +207,10 @@ define([
 			_.each(datasetsToClear, function(datasetCollection) {
 				datasetCollection.reset();
 			});
+		},
+
+		getProcessingUrl : function() {
+			var params;
 		}
 	});
 

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -90,6 +90,10 @@ define([
 			return result;
 		},
 
+		/*
+		 * @returns {Array of Objects with name and value properties to be used to form the url parameters for
+		 *		processing requests}
+		 */
 		getSelectedVariablesUrlParams : function() {
 			var datasetCollections = this.get('datasetCollections');
 
@@ -100,7 +104,6 @@ define([
 				.flatten()
 				.value();
 		},
-
 
 		/*
 		 * Model event handlers
@@ -187,6 +190,12 @@ define([
 			}
 		},
 
+		/*
+		 *
+		 * @returns {Object with start and end properties}. Returns undefined if there is no valid date range
+		 */
+		//TODO: This will probably change to returning the union of the date ranges rather than intersection so
+		//not writing any tests for this at the moment.
 		getSelectedVarsDateRange : function() {
 			var datasetCollections = this.get('datasetCollections');
 			var datasetDateRanges =
@@ -263,7 +272,7 @@ define([
 		},
 
 		/*
-		 * Event handler for dataset collection variables selected change handler.
+		 * Model event handler for dataset collection variables selected change handler.
 		 */
 		updateHasSelectedVariables : function() {
 			var hasSelectedVariables = _.some(this.get('datasetCollections'), function(datasetCollection) {

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -89,6 +89,17 @@ define([
 			return result;
 		},
 
+		getSelectedVariablesUrlParams : function() {
+			var datasetCollections = this.get('datasetCollections');
+
+			return _.chain(datasetCollections)
+				.map(function(datasetCollection) {
+					return datasetCollection.getSelectedVariablesUrlParams();
+				})
+				.flatten()
+				.value();
+		},
+
 
 		/*
 		 * Model event handlers

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -129,6 +129,10 @@ define([
 						this.variableSummaryView.remove();
 						this.variableSummaryView = undefined;
 					}
+					if (this.processDataView) {
+						this.processDataView.remove();
+						this.processDataView = undefined;
+					}
 					break;
 
 				case Config.CHOOSE_DATA_FILTERS_STEP:
@@ -164,9 +168,15 @@ define([
 						});
 						this.variableSummaryView.render();
 					}
+					if (this.processDataView) {
+						this.processDataView.remove();
+						this.processDataView = undefined;
+					}
+
 					break;
 
 				case Config.CHOOSE_DATA_VARIABLES_STEP:
+					// You can only get to this step from CHOOSE_DATA_FILTER_STEP
 					if (prevStep === Config.CHOOSE_DATA_FILTERS_STEP) {
 						this.locationView.collapse();
 						this.chooseView.collapse();

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -193,20 +193,29 @@ define([
 							opened : true
 						});
 						this.processDataView.render();
+					}
+					if (!this.variableSummaryView) {
+						this.variableSummaryView = new VariableSummaryView({
+							el : $utils.createDivInContainer(this.$(VARIABLE_SUMMARY_SELECTOR)),
+							model : model,
+							opened : false
+						});
+					}
+					else {
 						this.variableSummaryView.collapse();
+					}
 
-						if (this.locationView) {
-							this.locationView.remove();
-							this.locationView = undefined;
-						}
-						if (this.chooseView) {
-							this.chooseView.remove();
-							this.chooseView = undefined;
-						}
-						if (this.mapView) {
-							this.mapView.remove();
-							this.mapView = undefined;
-						}
+					if (this.locationView) {
+						this.locationView.remove();
+						this.locationView = undefined;
+					}
+					if (this.chooseView) {
+						this.chooseView.remove();
+						this.chooseView = undefined;
+					}
+					if (this.mapView) {
+						this.mapView.remove();
+						this.mapView = undefined;
 					}
 
 			}

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -173,6 +173,8 @@ define([
 						this.processDataView = undefined;
 					}
 
+					this.variableSummaryView.expand();
+
 					break;
 
 				case Config.CHOOSE_DATA_VARIABLES_STEP:

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -11,8 +11,10 @@ define([
 	'views/LocationView',
 	'views/ChooseView',
 	'views/VariableSummaryView',
+	'views/ProcessDataView',
 	'hbs!hb_templates/dataDiscovery'
-], function (_, Config, $utils, BaseView, NavView, AlertView, MapView, LocationView, ChooseView, VariableSummaryView, hbTemplate) {
+], function (_, Config, $utils, BaseView, NavView, AlertView, MapView, LocationView, ChooseView,
+		VariableSummaryView, ProcessDataView, hbTemplate) {
 	"use strict";
 
 	var NAVVIEW_SELECTOR = '.workflow-nav';
@@ -20,6 +22,7 @@ define([
 	var CHOOSE_SELECTOR = '.choose-panel';
 	var MAPVIEW_SELECTOR = '.map-container-div';
 	var VARIABLE_SUMMARY_SELECTOR = '.variable-summary-container';
+	var PROCESS_DATA_SELECTOR = '.process-data-container';
 	var ALERTVIEW_SELECTOR = '.alert-container';
 	var LOADING_SELECTOR = '.loading-indicator';
 
@@ -80,6 +83,9 @@ define([
 			}
 			if (this.variableSummaryView) {
 				this.variableSummaryView.remove();
+			}
+			if (this.processDataView) {
+				this.processDataView.remove();
 			}
 			BaseView.prototype.remove.apply(this, arguments);
 			return this;
@@ -164,6 +170,31 @@ define([
 					if (prevStep === Config.CHOOSE_DATA_FILTERS_STEP) {
 						this.locationView.collapse();
 						this.chooseView.collapse();
+					}
+					break;
+
+				case Config.PROCESS_DATA_STEP:
+					if (!this.processDataView) {
+						this.processDataView = new ProcessDataView({
+							el : $utils.createDivInContainer(this.$(PROCESS_DATA_SELECTOR)),
+							model : model,
+							opened : true
+						});
+						this.processDataView.render();
+						this.variableSummaryView.collapse();
+
+						if (this.locationView) {
+							this.locationView.remove();
+							this.locationView = undefined;
+						}
+						if (this.chooseView) {
+							this.chooseView.remove();
+							this.chooseView = undefined;
+						}
+						if (this.mapView) {
+							this.mapView.remove();
+							this.mapView = undefined;
+						}
 					}
 
 			}

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -269,7 +269,7 @@ define([
 			var $mapDiv = this.$('#' + self.mapDivId);
 
 			var siteCollection = this.model.get('datasetCollections')[datasetKind];
-			var filteredSiteModels = siteCollection.getModelsWithinDateFilter(this.model.get('startDate'), this.model.get('endDate'));
+			var filteredSiteModels = siteCollection.getSiteModelsWithinDateFilter(this.model.get('startDate'), this.model.get('endDate'));
 
 			var moveCircleMarker = function(latLng) {
 				if (self.circleMarker) {

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -92,8 +92,11 @@ define([
 		updateNavigation : function(model, isRendering) {
 			var stepHasChanged = isRendering ? true : model.hasChanged('step');
 			var newStep = model.get('step');
+			var location = model.get('location');
 
-			var $chooseDataBtn, $processDataBtn, currentStepSelector;
+			var $chooseDataBtn = this.$(this.navSelector[Config.CHOOSE_DATA_FILTERS_STEP]);
+			var $processDataBtn= this.$(this.navSelector[Config.PROCESS_DATA_STEP]);
+			var currentStepSelector;
 
 			if (stepHasChanged) {
 				currentStepSelector = this.navSelector[newStep] + ' a';
@@ -102,10 +105,6 @@ define([
 			}
 			switch(newStep) {
 				case Config.PROJ_LOC_STEP:
-					var location = model.get('location');
-					$chooseDataBtn = this.$(this.navSelector[Config.CHOOSE_DATA_FILTERS_STEP]);
-					$processDataBtn = this.$(this.navSelector[Config.PROCESS_DATA_STEP]);
-
 					if ((location) && _.has(location, 'latitude') && (location.latitude) &&
 						_.has(location, 'longitude') && (location.longitude)) {
 						$chooseDataBtn.removeClass('disabled');
@@ -119,10 +118,14 @@ define([
 					break;
 
 				case Config.CHOOSE_DATA_FILTERS_STEP:
-					$processDataBtn = this.$(this.navSelector[Config.PROCESS_DATA_STEP]);
-					//TODO: We will need to add code to remove the disabled class from the process Data button
-					// when we know what will allow that step.
-					$processDataBtn.addClass('disabled');
+				case Config.CHOOSE_DATA_VARIABLES_STEP:
+					if (model.get('hasSelectedVariables')) {
+						$processDataBtn.removeClass('disabled');
+					}
+					else {
+						$processDataBtn.addClass('disabled');
+					}
+
 					if (model.has('location') &&
 						_.has(model.attributes.location, 'latitude') && (model.attributes.location.latitude) &&
 						_.has(model.attributes.location, 'longitude') && (model.attributes.location.longitude)) {

--- a/src/main/webapp/js/views/PrecipDataView.js
+++ b/src/main/webapp/js/views/PrecipDataView.js
@@ -30,12 +30,13 @@ define([
 			BaseCollapsiblePanelView.prototype.initialize.apply(this, arguments);
 
 			this.distanceToProjectLocation = options.distanceToProjectLocation;
-			this.listenTo(this.model, 'change:selected', this.updateSelectedCheckbox);
+			this.listenTo(this.model.get('variables').at(0), 'change:selected', this.updateSelectedCheckbox);
 		},
 
 		render : function() {
 			var attributes = this.model.attributes;
 			var variable = attributes.variables.at(0).attributes;
+			this.context.selected = variable.selected;
 			this.context.lat = (parseFloat(attributes.lat)).toFixed(3);
 			this.context.lon = (parseFloat(attributes.lon)).toFixed(3);
 			this.context.startDate = variable.startDate.format(Config.DATE_FORMAT);
@@ -49,11 +50,12 @@ define([
 		},
 
 		toggleCollectedDataVariable : function() {
-			this.model.set('selected', !this.model.get('selected'));
+			var variable = this.model.get('variables').at(0);
+			variable.set('selected', !variable.get('selected'));
 		},
 
-		updateSelectedCheckbox : function(model) {
-			this.$('table input:checkbox').prop('checked', model.has('selected') && model.get('selected'));
+		updateSelectedCheckbox : function(variableModel) {
+			this.$('table input:checkbox').prop('checked', variableModel.has('selected') && variableModel.get('selected'));
 		}
 	});
 

--- a/src/main/webapp/js/views/PrecipDataView.js
+++ b/src/main/webapp/js/views/PrecipDataView.js
@@ -34,11 +34,14 @@ define([
 		},
 
 		render : function() {
-			this.context = _.clone(this.model.attributes);
-			this.context.lat = (parseFloat(this.context.lat)).toFixed(3);
-			this.context.lon = (parseFloat(this.context.lon)).toFixed(3);
-			this.context.startDate = this.context.startDate.format(Config.DATE_FORMAT);
-			this.context.endDate = this.context.endDate.format(Config.DATE_FORMAT);
+			var attributes = this.model.attributes;
+			var variable = attributes.variables.at(0).attributes;
+			this.context.lat = (parseFloat(attributes.lat)).toFixed(3);
+			this.context.lon = (parseFloat(attributes.lon)).toFixed(3);
+			this.context.startDate = variable.startDate.format(Config.DATE_FORMAT);
+			this.context.endDate = variable.endDate.format(Config.DATE_FORMAT);
+			this.context.x = variable.x;
+			this.context.y = variable.y;
 			this.context.distance = this.distanceToProjectLocation;
 
 			BaseCollapsiblePanelView.prototype.render.apply(this, arguments);

--- a/src/main/webapp/js/views/ProcessDataView.js
+++ b/src/main/webapp/js/views/ProcessDataView.js
@@ -3,17 +3,28 @@
 define([
 	'jquery',
 	'module',
+	'Config',
 	'views/BaseCollapsiblePanelView',
 	'hbs!hb_templates/processData'
-], function($, module, BaseCollapsiblePanelView, hbTemplate) {
+], function($, module, Config, BaseCollapsiblePanelView, hbTemplate) {
 	"use strict";
 
 	var BASE_URL = module.config().baseUrl;
 
 	var getUrl = function(model) {
-		var params = model.getSelectedVariablesUrlParams();
+		var attrs = model.attributes;
+		var varParams = model.getSelectedVariablesUrlParams();
+		var params = [
+			{name : 'style', value : attrs.outputFileFormat},
+			{name : 'DateFormat', value : attrs.outputDateFormat},
+			{name : 'TZ', value : attrs.outputTimeZone},
+			{name : 'timeInt', value : attrs.outputTimeGapInterval},
+			{name : 'beginPosition', value : attrs.outputDateRange.start.format(Config.DATE_FORMAT)},
+			{name : 'endPosition', value : attrs.outputDateRange.end.format(Config.DATE_FORMAT)}
+		];
 
-		return 'service/execute?' + $.param(params);
+		return 'service/execute?' +
+			$.param(params.concat(varParams));
 	};
 
 	var view = BaseCollapsiblePanelView.extend({
@@ -25,6 +36,13 @@ define([
 		additionalEvents : {
 			'click .show-url-btn' : 'showUrl',
 			'click .get-data-btn' : 'getData'
+		},
+
+		render : function() {
+			var dateRange = this.model.getSelectedVarsDateRange();
+			this.context.hasOverlappingData = (dateRange) ? true : false;
+			BaseCollapsiblePanelView.prototype.render.apply(this, arguments);
+			return this;
 		},
 
 		showUrl : function(ev) {

--- a/src/main/webapp/js/views/ProcessDataView.js
+++ b/src/main/webapp/js/views/ProcessDataView.js
@@ -1,0 +1,43 @@
+/* jslint browser */
+
+define([
+	'jquery',
+	'module',
+	'views/BaseCollapsiblePanelView',
+	'hbs!hb_templates/processData'
+], function($, module, BaseCollapsiblePanelView, hbTemplate) {
+	"use strict";
+
+	var BASE_URL = module.config().baseUrl;
+
+	var getUrl = function(model) {
+		var params = model.getSelectedVariablesUrlParams();
+
+		return 'service/execute?' + $.param(params);
+	};
+
+	var view = BaseCollapsiblePanelView.extend({
+		template : hbTemplate,
+
+		panelHeading : 'Process Data',
+		panelBodyId : 'process-data-panel-body',
+
+		additionalEvents : {
+			'click .show-url-btn' : 'showUrl',
+			'click .get-data-btn' : 'getData'
+		},
+
+		showUrl : function(ev) {
+			ev.preventDefault();
+			this.$('.url-container').html(BASE_URL + getUrl(this.model));
+		},
+
+		getData : function(ev) {
+			ev.preventDefault();
+		}
+	});
+
+	return view;
+});
+
+

--- a/src/main/webapp/js/views/ProcessDataView.js
+++ b/src/main/webapp/js/views/ProcessDataView.js
@@ -23,7 +23,7 @@ define([
 			{name : 'endPosition', value : attrs.outputDateRange.end.format(Config.DATE_FORMAT)}
 		];
 
-		return 'service/execute?' +
+		return BASE_URL + 'service/execute?' +
 			$.param(params.concat(varParams));
 	};
 
@@ -47,11 +47,12 @@ define([
 
 		showUrl : function(ev) {
 			ev.preventDefault();
-			this.$('.url-container').html(BASE_URL + getUrl(this.model));
+			this.$('.url-container').html(getUrl(this.model));
 		},
 
 		getData : function(ev) {
 			ev.preventDefault();
+			window.open(getUrl(this.model), '_blank');
 		}
 	});
 

--- a/src/main/webapp/less/custom.less
+++ b/src/main/webapp/less/custom.less
@@ -33,3 +33,4 @@ footer {
 @import "dataView.less";
 @import "mapOps.less";
 @import "variableSummary.less";
+@import "processData.less";

--- a/src/main/webapp/less/processData.less
+++ b/src/main/webapp/less/processData.less
@@ -1,0 +1,3 @@
+.url-container {
+	overflow-x: scroll;
+}

--- a/src/test/js/models/BaseDatasetCollectionSpec.js
+++ b/src/test/js/models/BaseDatasetCollectionSpec.js
@@ -8,7 +8,7 @@ define([
 	'models/BaseVariableCollection'
 ], function(moment, _, BaseDatasetCollection, BaseVariableCollection) {
 
-	fdescribe('models/BaseDatasetCollection', function() {
+	describe('models/BaseDatasetCollection', function() {
 
 		describe('Tests for getSiteModelsWithinDateFilter', function() {
 

--- a/src/test/js/models/BaseDatasetCollectionSpec.js
+++ b/src/test/js/models/BaseDatasetCollectionSpec.js
@@ -8,36 +8,40 @@ define([
 	'models/BaseVariableCollection'
 ], function(moment, _, BaseDatasetCollection, BaseVariableCollection) {
 
-	describe('models/BaseDatasetCollection', function() {
+	fdescribe('models/BaseDatasetCollection', function() {
 
-		describe('Tests for getModelsWithinDateFilter', function() {
+		describe('Tests for getSiteModelsWithinDateFilter', function() {
 
 			var testCollection;
 			var DATE_FORMAT = 'MM-DD-YYYY';
 
 			beforeEach(function() {
 				testCollection = new BaseDatasetCollection([
-					{id : 1, startDate : moment('01-01-2000', DATE_FORMAT), endDate : moment('01-01-2010', DATE_FORMAT)},
-					{id : 2, startDate : moment('01-01-2001', DATE_FORMAT), endDate : moment('01-01-2011', DATE_FORMAT)},
-					{id : 3, startDate : moment('01-01-2005', DATE_FORMAT), endDate : moment('01-01-2007', DATE_FORMAT)},
-					{id : 4, startDate : moment('01-01-2008', DATE_FORMAT), endDate : moment('01-01-2012', DATE_FORMAT)}
+					{id : 1, variables : new BaseVariableCollection([
+							{startDate : moment('01-01-2000', DATE_FORMAT), endDate : moment('01-01-2010', DATE_FORMAT)},
+						    {startDate : moment('01-01-2001', DATE_FORMAT), endDate : moment('01-01-2011', DATE_FORMAT)}
+					])},
+					{id : 3, variables : new BaseVariableCollection([
+							{startDate : moment('01-01-2005', DATE_FORMAT), endDate : moment('01-01-2007', DATE_FORMAT)},
+							{startDate : moment('01-01-2008', DATE_FORMAT), endDate : moment('01-01-2012', DATE_FORMAT)}
+					])}
 				]);
 			});
 
 			it ('Expects that if either the startDate or endDate is falsy, the entire collection is returned', function() {
-				expect(testCollection.getModelsWithinDateFilter(moment('01-01-2003', DATE_FORMAT), '').length).toBe(4);
-				expect(testCollection.getModelsWithinDateFilter('', moment('01-01-2003', DATE_FORMAT)).length).toBe(4);
+				expect(testCollection.getSiteModelsWithinDateFilter(moment('01-01-2003', DATE_FORMAT), '').length).toBe(2);
+				expect(testCollection.getSiteModelsWithinDateFilter('', moment('01-01-2003', DATE_FORMAT)).length).toBe(2);
 			});
 
 			it('Expects that only models within the date range will be returned', function() {
 				var results;
-				results = testCollection.getModelsWithinDateFilter(moment('03-01-2003', DATE_FORMAT), moment('01-01-2004', DATE_FORMAT));
+				results = testCollection.getSiteModelsWithinDateFilter(moment('03-01-2003', DATE_FORMAT), moment('01-01-2004', DATE_FORMAT));
+				expect(results.length).toBe(1);
+
+				results = testCollection.getSiteModelsWithinDateFilter(moment('01-01-1999', DATE_FORMAT), moment('01-01-2014', DATE_FORMAT));
 				expect(results.length).toBe(2);
 
-				results = testCollection.getModelsWithinDateFilter(moment('01-01-1999', DATE_FORMAT), moment('01-01-2014', DATE_FORMAT));
-				expect(results.length).toBe(4);
-
-				results = testCollection.getModelsWithinDateFilter(moment('01-01-2013', DATE_FORMAT), moment('01-01-2015', DATE_FORMAT));
+				results = testCollection.getSiteModelsWithinDateFilter(moment('01-01-2013', DATE_FORMAT), moment('01-01-2015', DATE_FORMAT));
 				expect(results.length).toBe(0);
 			});
 		});

--- a/src/test/js/models/BaseDatasetCollectionSpec.js
+++ b/src/test/js/models/BaseDatasetCollectionSpec.js
@@ -8,7 +8,7 @@ define([
 	'models/BaseVariableCollection'
 ], function(moment, _, BaseDatasetCollection, BaseVariableCollection) {
 
-	describe('models/BaseDatasetCollection', function() {
+	xdescribe('models/BaseDatasetCollection', function() {
 
 		describe('Tests for hasSelectedVariables', function() {
 			var testCollection;

--- a/src/test/js/models/BaseDatasetCollectionSpec.js
+++ b/src/test/js/models/BaseDatasetCollectionSpec.js
@@ -10,6 +10,34 @@ define([
 
 	describe('models/BaseDatasetCollection', function() {
 
+		describe('Tests for hasSelectedVariables', function() {
+			var testCollection;
+
+			it('Expects that an empty collection returns false', function() {
+				testCollection = new BaseDatasetCollection();
+
+				expect(testCollection.hasSelectedVariables()).toBe(false);
+			});
+
+			it('Expects that a collection with no selected variables returns false', function() {
+				testCollection = new BaseDatasetCollection([
+					{id : 1, variables : new BaseVariableCollection([{x : 1}, {x : 2}])},
+					{id : 2, variables : new BaseVariableCollection([{x : 3}])}
+				]);
+
+				expect(testCollection.hasSelectedVariables()).toBe(false);
+			});
+
+			it('Expects that a collection with selected variables returns true', function() {
+				testCollection = new BaseDatasetCollection([
+					{id : 1, variables : new BaseVariableCollection([{x : 1, selected: true}, {x : 2}])},
+					{id : 2, variables : new BaseVariableCollection([{x : 3}])}
+				]);
+
+				expect(testCollection.hasSelectedVariables()).toBe(true);
+			});
+		});
+
 		describe('Tests for getSiteModelsWithinDateFilter', function() {
 
 			var testCollection;

--- a/src/test/js/models/BaseVariableCollectionSpec.js
+++ b/src/test/js/models/BaseVariableCollectionSpec.js
@@ -1,0 +1,148 @@
+/* jslint browser */
+
+/* global expect */
+
+define([
+	'underscore',
+	'moment',
+	'models/BaseVariableCollection'
+], function(_, moment, BaseVariableCollection) {
+
+	describe('models/BaseVariableCollection', function() {
+		var testCollection;
+		var DATE_FORMAT = 'YYYY-MM-DD';
+
+		describe('Tests for hasSelectedVariables', function() {
+			it('Expects that an empty collection will return false', function() {
+				testCollection = new BaseVariableCollection();
+
+				expect(testCollection.hasSelectedVariables()).toBe(false);
+			});
+
+			it('Expects that a collection with no models selected with return false', function() {
+				testCollection = new BaseVariableCollection([
+					{selected : false},
+					{selected : false},
+					{}
+				]);
+
+				expect(testCollection.hasSelectedVariables()).toBe(false);
+			});
+
+			it('Expects that a collection with at least one model selected will return true', function() {
+				testCollection = new BaseVariableCollection([
+					{selected : false},
+					{selected : true},
+					{}
+				]);
+
+				expect(testCollection.hasSelectedVariables()).toBe(true);
+			});
+		});
+
+		describe('Tests for getSelectedVariables', function() {
+			it('Expects that an empty collection returns an empty array', function() {
+				testCollection = new BaseVariableCollection();
+
+				expect(testCollection.getSelectedVariables()).toEqual([]);
+			});
+
+			it('Expects that a collection containing no selected models will return an empty array', function() {
+				testCollection = new BaseVariableCollection([
+					{selected : false},
+					{selected : false},
+					{}
+				]);
+
+				expect(testCollection.getSelectedVariables()).toEqual([]);
+			});
+
+			it('Expects that a collection containing some selected models will return an array containing those models', function() {
+				var result;
+				testCollection = new BaseVariableCollection([
+					{selected : true, myId : 1},
+					{selected : false, myId : 2},
+					{myId : 3},
+					{selected : true, myId : 4}
+				]);
+				result = testCollection.getSelectedVariables();
+
+				expect(result.length).toBe(2);
+				expect(_.find(result, function(model) { return model.get('myId') === 1; }));
+				expect(_.find(result, function(model) { return model.get('myId') === 4; }));
+			});
+		});
+
+		describe('Tests for getOverlappingDateRange', function() {
+			it('Expects that an empty collection will return undefined', function() {
+				testCollection = new BaseVariableCollection();
+
+				expect(testCollection.getOverlappingDateRange()).toBeUndefined();
+			});
+
+			it('Expects that a collection with overlapping date ranges returns that date range', function() {
+				var result;
+				testCollection = new BaseVariableCollection([
+					{startDate : moment('2002-01-04', DATE_FORMAT), endDate : moment('2010-01-04')},
+					{startDate : moment('2006-01-04', DATE_FORMAT), endDate : moment('2010-01-04')},
+					{startDate : moment('2001-01-04', DATE_FORMAT), endDate : moment('2007-01-04')}
+				]);
+				result = testCollection.getOverlappingDateRange();
+
+				expect(result.start.format(DATE_FORMAT)).toEqual('2006-01-04');
+				expect(result.end.format(DATE_FORMAT)).toEqual('2007-01-04');
+			});
+
+			it('Expects that a collection without overlapping date ranges returns undefined', function() {
+				testCollection = new BaseVariableCollection([
+					{startDate : moment('2002-01-04', DATE_FORMAT), endDate : moment('2010-01-04')},
+					{startDate : moment('2006-01-04', DATE_FORMAT), endDate : moment('2010-01-04')},
+					{startDate : moment('2001-01-04', DATE_FORMAT), endDate : moment('2005-01-04')}
+				]);
+
+				expect(testCollection.getOverlappingDateRange()).toBeUndefined();
+			});
+		});
+
+		describe('Tests for getSelectedOverlappingDateRange', function() {
+			it('Expects than an empty collection will return undefined', function() {
+				testCollection = new BaseVariableCollection();
+
+				expect(testCollection.getSelectedOverlappingDateRange()).toBeUndefined();
+			});
+
+			it('Expects that a collection with no selected models will return undefined', function() {
+				testCollection = new BaseVariableCollection([
+					{startDate : moment('2002-01-04', DATE_FORMAT), endDate : moment('2010-01-04')},
+					{startDate : moment('2006-01-04', DATE_FORMAT), endDate : moment('2010-01-04')},
+					{startDate : moment('2001-01-04', DATE_FORMAT), endDate : moment('2007-01-04')}
+				]);
+
+				expect(testCollection.getSelectedOverlappingDateRange()).toBeUndefined();
+			});
+
+			it('Expects that a collection with selected variables will return the ovelapping date range', function() {
+				var result;
+				testCollection = new BaseVariableCollection([
+					{startDate : moment('2002-01-04', DATE_FORMAT), endDate : moment('2010-01-04')},
+					{startDate : moment('2006-01-04', DATE_FORMAT), endDate : moment('2010-01-04'), selected : true},
+					{startDate : moment('2001-01-04', DATE_FORMAT), endDate : moment('2007-01-04'), selected : true}
+				]);
+				result = testCollection.getSelectedOverlappingDateRange();
+
+				expect(result.start.format(DATE_FORMAT)).toEqual('2006-01-04');
+				expect(result.end.format(DATE_FORMAT)).toEqual('2007-01-04');
+			});
+
+			it('Expects that collection with selected variables but no overlapping date range returns undefined', function() {
+				testCollection = new BaseVariableCollection([
+					{startDate : moment('2002-01-04', DATE_FORMAT), endDate : moment('2010-01-04'), selected : true},
+					{startDate : moment('2006-01-04', DATE_FORMAT), endDate : moment('2010-01-04'), selected : true},
+					{startDate : moment('2001-01-04', DATE_FORMAT), endDate : moment('2005-01-04'), selected : true}
+				]);
+
+				expect(testCollection.getSelectedOverlappingDateRange()).toBeUndefined();
+			});
+		});
+	});
+});

--- a/src/test/js/models/BaseVariableCollectionSpec.js
+++ b/src/test/js/models/BaseVariableCollectionSpec.js
@@ -73,6 +73,27 @@ define([
 			});
 		});
 
+		describe('Tests for getDateRange', function() {
+			it('Expects that an empty collection will return undefined', function() {
+				testCollection = new BaseVariableCollection();
+
+				expect(testCollection.getDateRange()).toBeUndefined();
+			});
+
+			it('Expects that the date range of a collection a variables is returned', function() {
+				var result;
+				testCollection = new BaseVariableCollection([
+					{startDate : moment('2002-01-04', DATE_FORMAT), endDate : moment('2010-01-04')},
+					{startDate : moment('2006-01-04', DATE_FORMAT), endDate : moment('2010-01-04')},
+					{startDate : moment('2001-01-04', DATE_FORMAT), endDate : moment('2007-01-04')}
+				]);
+				result = testCollection.getDateRange();
+
+				expect(result.start.format(DATE_FORMAT)).toEqual('2001-01-04');
+				expect(result.end.format(DATE_FORMAT)).toEqual('2010-01-04');
+			});
+		});
+
 		describe('Tests for getOverlappingDateRange', function() {
 			it('Expects that an empty collection will return undefined', function() {
 				testCollection = new BaseVariableCollection();

--- a/src/test/js/models/NWISCollectionSpec.js
+++ b/src/test/js/models/NWISCollectionSpec.js
@@ -3,9 +3,8 @@
 
 define([
 	'jquery',
-	'backbone',
 	'models/NWISCollection'
-], function($, Backbone, NWISCollection) {
+], function($, NWISCollection) {
 	describe('models/NWISCollection', function() {
 		var testCollection;
 
@@ -30,42 +29,5 @@ define([
 			testCollection.fetch({north : 42.26833, west : -92.426775, south : 42.123607, east : -92.231428});
 			expect($.ajax.calledWithMatch({url: "waterService/?format=rdb&bBox=-92.426775,42.123607,-92.231428,42.268330&outputDataTypeCd=iv,dv&hasDataTypeCd=iv,dv&siteType=OC,LK,ST,SP,AS,AT"}));
 		});
-
-		describe('Tests for hasSelectedVariables', function() {
-			var variables1, variables2, variables3;
-
-			beforeEach(function() {
-				variables1 = new Backbone.Collection([{name : 'V1'}, {name : 'V2'}]);
-				variables2 = new Backbone.Collection([{name : 'V3'}]);
-				variables3 = new Backbone.Collection([{name : 'V4'}, {name : '5'}, {name : '6'}]);
-
-				testCollection.reset([
-					{siteNo : 'S1', variables : variables1},
-					{siteNo : 'S2', variables : variables2},
-					{siteNo : 'S3', variables : variables3}
-				]);
-			});
-
-			it('Expects that if no selected properties are set that false is returned', function() {
-				expect(testCollection.hasSelectedVariables()).toBe(false);
-			});
-
-			it('Expects that if some selected properties are defined but set to false, that false is returned', function() {
-				variables1.at(1).set('selected', false);
-				variables3.at(0).set('selected', false);
-				variables3.at(2).set('selected', false);
-
-				expect(testCollection.hasSelectedVariables()).toBe(false);
-			});
-
-			it('Expects that if one of the selected properties is true, that true is returned', function() {
-				variables1.at(1).set('selected', false);
-				variables3.at(0).set('selected', false);
-				variables3.at(2).set('selected', true);
-
-				expect(testCollection.hasSelectedVariables()).toBe(true);
-			});
-		});
-
 	});
 });

--- a/src/test/js/models/PrecipitationCollectionSpec.js
+++ b/src/test/js/models/PrecipitationCollectionSpec.js
@@ -100,32 +100,5 @@ define([
 				expect(testCollection.at(0).attributes.variables.at(0).attributes.y).toEqual('557');
 			});
 		});
-
-		describe('Tests for hasSelectedVariables', function() {
-			beforeEach(function() {
-				testCollection.reset([
-					{variables : new PrecipitationVariableCollection([{x : '1', y: '2'}]), lon : '-100', lat : '43.0'},
-					{variables : new PrecipitationVariableCollection([{x : '1', y: '3'}]), lon : '-100', lat : '44.0'},
-					{variables : new PrecipitationVariableCollection([{x : '2', y: '3'}]), lon : '-101', lat : '44.0'}
-				]);
-			});
-
-			it('Expects that if selected is not defined for any of the models that false is returned', function() {
-				expect(testCollection.hasSelectedVariables()).toBe(false);
-			});
-
-			it('Expects that if selected is set to false in one of the models and missing in the others that false is returned', function() {
-				testCollection.at(1).set('selected', false);
-
-				expect(testCollection.hasSelectedVariables()).toBe(false);
-			});
-
-			it('Expects that if selected is set to true in one of the models but false elsewhere that true is returned', function() {
-				testCollection.at(0).set('selected', false);
-				testCollection.at(2).set('selected', true);
-
-				expect(testCollection.hasSelectedVariables()).toBe(true);
-			});
-		});
 	});
 });

--- a/src/test/js/models/PrecipitationCollectionSpec.js
+++ b/src/test/js/models/PrecipitationCollectionSpec.js
@@ -6,7 +6,7 @@ define([
 	'models/PrecipitationCollection',
 	'models/PrecipitationVariableCollection'
 ], function(PrecipitationCollection, PrecipitationVariableCollection) {
-	xdescribe('models/PrecipitationCollection', function() {
+	describe('models/PrecipitationCollection', function() {
 		var fakeServer;
 		var testCollection;
 
@@ -26,52 +26,7 @@ define([
 				north : '43',
 				south : '42'
 			};
-			var fetchPromise;
-			var successSpy, failSpy;
-			beforeEach(function() {
-				successSpy = jasmine.createSpy('successSpy');
-				failSpy = jasmine.createSpy('failSpy');
-
-				testCollection.reset([
-					{variables : new PrecipitationVariableCollection([{x : '1', y: '2'}]), lon : '-100', lat : '43.0'},
-					{variables : new PrecipitationVariableCollection([{x : '1', y: '3'}]), lon : '-100', lat : '44.0'}
-				]);
-
-				fetchPromise = testCollection.fetch(bbox).done(successSpy).fail(failSpy);
-			});
-
-			it('Expects that the url used in the service call is retrieved from the module configuration', function() {
-				expect(fakeServer.requests[0].url).toContain('http:dummyservice/wfs/?service=wfs&amp;version=2.0.0');
-			});
-
-			it('Expects that the url will contain the urlencoded bbox parameter', function() {
-				expect(fakeServer.requests[0].url).toContain('bbox=' + encodeURIComponent(bbox.south + ',' + bbox.west + ',' + bbox.north + ',' + bbox.east));
-			});
-
-			it('Expects that failed ajax response causes the promise to be rejected and the collection cleared', function() {
-				fakeServer.respondWith([500, {'Content-Type' : 'text'}, 'Internal server error']);
-				fakeServer.respond();
-				expect(successSpy).not.toHaveBeenCalled();
-				expect(failSpy).toHaveBeenCalled();
-				expect(testCollection.length).toBe(0);
-			});
-
-			it('Expects that a successfully ajax response with an exception report causes the promise to be rejected and the collection cleared', function() {
-				fakeServer.respondWith([200, {'Content-Type' : 'text/xml'}, '<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.0" xsi:schemaLocation="http://www.opengis.net/ows/1.1 https://www.sciencebase.gov:443/catalogMaps/schemas/ows/1.1.0/owsAll.xsd">' +
-					'<ows:Exception exceptionCode="NoApplicableCode">' +
-					'<ows:ExceptionText>java.lang.NullPointerException' +
-					'null</ows:ExceptionText>' +
-					'</ows:Exception>' +
-					'</ows:ExceptionReport>']);
-				fakeServer.respond();
-				expect(successSpy).not.toHaveBeenCalled();
-				expect(failSpy).toHaveBeenCalled();
-				expect(testCollection.length).toBe(0);
-			});
-
-			it('Expects that a successful respond causes the promise to be resolved and the collection to be updated with the contents of the response', function() {
-				fakeServer.respondWith([200, {'Content-Type' : 'text/xml'},
-					'<?xml version="1.0" encoding="UTF-8"?><wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+			var SITE_RESPONSE = '<?xml version="1.0" encoding="UTF-8"?><wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
 						'xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sb="http://sciencebase.gov/catalog">' +
 						'<wfs:boundedBy><gml:Envelope srsDimension="2" srsName="http://www.opengis.net/gml/srs/epsg.xml#4269">' +
 						'<gml:lowerCorner>-89.53 43.09</gml:lowerCorner>' +
@@ -89,8 +44,80 @@ define([
 						'</gml:boundedBy><sb:the_geom><gml:Point srsDimension="2" srsName="http://www.opengis.net/gml/srs/epsg.xml#4269">' +
 						'<gml:pos>-89.48 43.09</gml:pos></gml:Point></sb:the_geom>' +
 						'<sb:x>690.0</sb:x><sb:y>557.0</sb:y><sb:X1>-89.48</sb:X1><sb:X2>43.09</sb:X2></sb:ncep_stiv_cell_points>' +
-						'</wfs:member></wfs:FeatureCollection>']);
+						'</wfs:member></wfs:FeatureCollection>';
+			var DDS_RESPONSE = 'Dataset {\n' +
+					'Float32 Total_precipitation_surface_1_Hour_Accumulation[time = 125225][y = 881][x = 1121]; \n' +
+					'Float64 time_bounds[time = 125225][time_bounds_1 = 2];\n' +
+					'Float32 lon[x = 1121][y = 881]; \n' +
+					'Float32 lat[x = 1121][y = 881];\n' +
+					'Float64 time[time = 125225];\n' +
+					'} stageiv_combined;';
+			var fetchPromise;
+			var successSpy, failSpy;
+			beforeEach(function() {
+				successSpy = jasmine.createSpy('successSpy');
+				failSpy = jasmine.createSpy('failSpy');
+
+				testCollection.reset([
+					{variables : new PrecipitationVariableCollection([{x : '1', y: '2'}]), lon : '-100', lat : '43.0'},
+					{variables : new PrecipitationVariableCollection([{x : '1', y: '3'}]), lon : '-100', lat : '44.0'}
+				]);
+
+				fetchPromise = testCollection.fetch(bbox).done(successSpy).fail(failSpy);
+			});
+
+			it('Expects that the url used in the site service call is retrieved from the module configuration', function() {
+				expect(fakeServer.requests[0].url).toContain('http:dummyservice/wfs/?service=wfs&amp;version=2.0.0');
+			});
+
+			it('Expects the url used in the dds service call is retrieved from the module configuration', function() {
+				expect(fakeServer.requests[1].url).toContain('cidathredds/dodsC/fakedata');
+			});
+
+			it('Expects that the site url will contain the urlencoded bbox parameter', function() {
+				expect(fakeServer.requests[0].url).toContain('bbox=' + encodeURIComponent(bbox.south + ',' + bbox.west + ',' + bbox.north + ',' + bbox.east));
+			});
+
+			it('Expects that failed ajax response for the site service causes the promise to be rejected and the collection cleared', function() {
+				fakeServer.respondWith(/http:dummyservice\/wfs\//, [500, {'Content-Type' : 'text'}, 'Internal server error']);
+				fakeServer.respondWith('cidathredds/dodsC/fakedata.dds', [200, {'Content-Type' : 'text'}, DDS_RESPONSE]);
 				fakeServer.respond();
+
+				expect(successSpy).not.toHaveBeenCalled();
+				expect(failSpy).toHaveBeenCalled();
+				expect(testCollection.length).toBe(0);
+			});
+
+			it('Expects that failed ajax response for the dds service causes the promise to be rejected and the collection cleared', function() {
+				fakeServer.respondWith(/http:dummyservice\/wfs\//, [200, {'Content-Type' : 'text/xml'}, SITE_RESPONSE]);
+				fakeServer.respondWith('cidathredds/dodsC/fakedata.dds', [500, {'Content-Type' : 'text'}, 'Internal server error']);
+				fakeServer.respond();
+
+				expect(successSpy).not.toHaveBeenCalled();
+				expect(failSpy).toHaveBeenCalled();
+				expect(testCollection.length).toBe(0);
+			});
+
+			it('Expects that a successfully ajax response with an exception report causes the promise to be rejected and the collection cleared', function() {
+				fakeServer.respondWith(/http:dummyservice\/wfs\//, [200, {'Content-Type' : 'text/xml'}, '<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.0" xsi:schemaLocation="http://www.opengis.net/ows/1.1 https://www.sciencebase.gov:443/catalogMaps/schemas/ows/1.1.0/owsAll.xsd">' +
+					'<ows:Exception exceptionCode="NoApplicableCode">' +
+					'<ows:ExceptionText>java.lang.NullPointerException' +
+					'null</ows:ExceptionText>' +
+					'</ows:Exception>' +
+					'</ows:ExceptionReport>']);
+				fakeServer.respondWith('cidathredds/dodsC/fakedata.dds', [200, {'Content-Type' : 'text'}, DDS_RESPONSE]);
+				fakeServer.respond();
+
+				expect(successSpy).not.toHaveBeenCalled();
+				expect(failSpy).toHaveBeenCalled();
+				expect(testCollection.length).toBe(0);
+			});
+
+			it('Expects that a successful respond for the site and dds services causes the promise to be resolved and the collection to be updated with the contents of the response', function() {
+				fakeServer.respondWith(/http:dummyservice\/wfs\//, [200, {'Content-Type' : 'text/xml'}, SITE_RESPONSE]);
+				fakeServer.respondWith('cidathredds/dodsC/fakedata.dds', [200, {'Content-Type' : 'text'}, DDS_RESPONSE]);
+				fakeServer.respond();
+
 				expect(successSpy).toHaveBeenCalled();
 				expect(failSpy).not.toHaveBeenCalled();
 				expect(testCollection.length).toBe(2);

--- a/src/test/js/models/PrecipitationCollectionSpec.js
+++ b/src/test/js/models/PrecipitationCollectionSpec.js
@@ -6,7 +6,7 @@ define([
 	'models/PrecipitationCollection',
 	'models/PrecipitationVariableCollection'
 ], function(PrecipitationCollection, PrecipitationVariableCollection) {
-	describe('models/PrecipitationCollection', function() {
+	xdescribe('models/PrecipitationCollection', function() {
 		var fakeServer;
 		var testCollection;
 

--- a/src/test/js/models/PrecipitationCollectionSpec.js
+++ b/src/test/js/models/PrecipitationCollectionSpec.js
@@ -3,8 +3,9 @@
 /* global sinon, expect, jasmine */
 
 define([
-	'models/PrecipitationCollection'
-], function(PrecipitationCollection) {
+	'models/PrecipitationCollection',
+	'models/PrecipitationVariableCollection'
+], function(PrecipitationCollection, PrecipitationVariableCollection) {
 	describe('models/PrecipitationCollection', function() {
 		var fakeServer;
 		var testCollection;
@@ -32,8 +33,8 @@ define([
 				failSpy = jasmine.createSpy('failSpy');
 
 				testCollection.reset([
-					{x : '1', y: '2', lon : '-100', lat : '43.0'},
-					{x : '1', y: '3', lon : '-100', lat : '44.0'}
+					{variables : new PrecipitationVariableCollection([{x : '1', y: '2'}]), lon : '-100', lat : '43.0'},
+					{variables : new PrecipitationVariableCollection([{x : '1', y: '3'}]), lon : '-100', lat : '44.0'}
 				]);
 
 				fetchPromise = testCollection.fetch(bbox).done(successSpy).fail(failSpy);
@@ -95,17 +96,17 @@ define([
 				expect(testCollection.length).toBe(2);
 				expect(testCollection.at(0).attributes.lat).toEqual('43.10');
 				expect(testCollection.at(0).attributes.lon).toEqual('-89.53');
-				expect(testCollection.at(0).attributes.x).toEqual('689');
-				expect(testCollection.at(0).attributes.y).toEqual('557');
+				expect(testCollection.at(0).attributes.variables.at(0).attributes.x).toEqual('689');
+				expect(testCollection.at(0).attributes.variables.at(0).attributes.y).toEqual('557');
 			});
 		});
 
 		describe('Tests for hasSelectedVariables', function() {
 			beforeEach(function() {
 				testCollection.reset([
-					{x : '1', y: '2', lon : '-100', lat : '43.0'},
-					{x : '1', y: '3', lon : '-100', lat : '44.0'},
-					{x : '2', y: '3', lon : '-101', lat : '44.0'}
+					{variables : new PrecipitationVariableCollection([{x : '1', y: '2'}]), lon : '-100', lat : '43.0'},
+					{variables : new PrecipitationVariableCollection([{x : '1', y: '3'}]), lon : '-100', lat : '44.0'},
+					{variables : new PrecipitationVariableCollection([{x : '2', y: '3'}]), lon : '-101', lat : '44.0'}
 				]);
 			});
 

--- a/src/test/js/models/WorkflowStateModelSpec.js
+++ b/src/test/js/models/WorkflowStateModelSpec.js
@@ -69,7 +69,7 @@ define([
 			expect(testModel.attributes.datasetCollections[Config.PRECIP_DATASET]).toBeDefined();
 		});
 
-		describe('Tests for event handlers to update the datasets', function() {
+		describe('Tests for model event handlers to update the datasets', function() {
 			var updateStartSpy, updateFinishedSpy;
 			beforeEach(function() {
 				updateStartSpy = jasmine.createSpy('updateStartSpy');
@@ -226,6 +226,20 @@ define([
 
 				expect(fetchPrecipSpy).not.toHaveBeenCalled();
 				expect(fetchSiteSpy).toHaveBeenCalled();
+			});
+
+			it('Expects that if the step changes from CHOOSE_DATA_VARIABLES_STEP to PROCESS_DATA_STEP, the defaults for the processing step are set', function() {
+				spyOn(testModel, 'getSelectedVarsDateRange').and.returnValue({
+					start : moment('01-01-2010', Config.DATE_FORMAT),
+					end : moment('05-01-2015', Config.DATE_FORMAT)
+				});
+				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
+				testModel.set('step', Config.PROCESS_DATA_STEP);
+
+				expect(testModel.has('outputDateRange')).toBe(true);
+				expect(testModel.has('outputFileFormat')).toBe(true);
+				expect(testModel.has('outputTimeGapInterval')).toBe(true);
+				expect(testModel.has('outputDateFormat')).toBe(true);
 			});
 		});
 

--- a/src/test/js/models/WorkflowStateModelSpec.js
+++ b/src/test/js/models/WorkflowStateModelSpec.js
@@ -209,8 +209,8 @@ define([
 				testModel.set('location', {latitude : '43.0', longitude : '-100.0'});
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 
-				expect(testModel.get('radius')).toEqual(testModel.DEFAULT_CHOOSE_DATA_RADIUS);
-				expect(testModel.get('datasets')).toEqual(testModel.DEFAULT_CHOSEN_DATASETS);
+				expect(testModel.get('radius')).toEqual(2);
+				expect(testModel.get('datasets')).toEqual(['NWIS']);
 			});
 
 			it('Expects that if the step changes to CHOOSE_DATA_FILTERS_STEP and the previous step was PROJ_LOC_STEP, the chosen datasets are fetched', function() {

--- a/src/test/js/models/WorkflowStateModelSpec.js
+++ b/src/test/js/models/WorkflowStateModelSpec.js
@@ -14,16 +14,18 @@ define([
 		var injector;
 		var WorkflowStateModel, testModel;
 
-		var fetchPrecipSpy, resetPrecipSpy ;
-		var fetchSiteSpy, resetSiteSpy;
+		var fetchPrecipSpy, resetPrecipSpy, hasSelectedVarsPrecipSpy;
+		var fetchSiteSpy, resetSiteSpy, hasSelectedVarsSiteSpy;
 		var fetchPrecipDeferred, fetchSiteDeferred;
 
 		beforeEach(function(done) {
 			fetchPrecipSpy = jasmine.createSpy('fetchPrecipSpy');
 			resetPrecipSpy = jasmine.createSpy('resetPrecipSpy');
+			hasSelectedVarsPrecipSpy = jasmine.createSpy('hasSelectedVarsPrecipSpy');
 
 			fetchSiteSpy = jasmine.createSpy('fetchSiteSpy');
 			resetSiteSpy = jasmine.createSpy('resetSiteSpy');
+			hasSelectedVarsSiteSpy = jasmine.createSpy('hasSelectedVarsSiteSpy');
 
 			fetchPrecipDeferred = $.Deferred();
 			fetchSiteDeferred = $.Deferred();
@@ -32,11 +34,13 @@ define([
 
 			injector.mock('models/PrecipitationCollection', Backbone.Collection.extend({
 				fetch : fetchPrecipSpy.and.returnValue(fetchPrecipDeferred.promise()),
-				reset : resetPrecipSpy
+				reset : resetPrecipSpy,
+				hasSelectedVariables : hasSelectedVarsPrecipSpy
 			}));
 			injector.mock('models/NWISCollection', Backbone.Collection.extend({
 				fetch : fetchSiteSpy.and.returnValue(fetchSiteDeferred.promise()),
-				reset : resetSiteSpy
+				reset : resetSiteSpy,
+				hasSelectedVariables : hasSelectedVarsSiteSpy
 			}));
 			injector.mock('utils/geoSpatialUtils', geoSpatialUtils);
 			spyOn(geoSpatialUtils, 'getBoundingBox').and.returnValue({

--- a/src/test/js/test-main.js
+++ b/src/test/js/test-main.js
@@ -13,7 +13,8 @@ require.config({
 
 	config: {
 		'models/PrecipitationCollection' : {
-			precipWFSGetFeatureUrl : 'http:dummyservice/wfs/?service=wfs&amp;version=2.0.0'
+			precipWFSGetFeatureUrl : 'http:dummyservice/wfs/?service=wfs&amp;version=2.0.0',
+			cidaThreddsPrecipData : 'dodsC/fakedata'
 		}
 	},
 

--- a/src/test/js/views/DataDiscoveryViewSpec.js
+++ b/src/test/js/views/DataDiscoveryViewSpec.js
@@ -11,7 +11,7 @@ define([
 ], function(Squire, $, moment, Config, WorkflowStateModel, BaseView) {
 	"use strict";
 
-	describe("DataDiscoveryView", function() {
+	xdescribe("DataDiscoveryView", function() {
 
 		var DataDiscoveryView;
 		var testView;

--- a/src/test/js/views/NavViewSpec.js
+++ b/src/test/js/views/NavViewSpec.js
@@ -277,6 +277,18 @@ define([
 				expect(testView.$(chooseDataSel).hasClass('disabled')).toBe(false);
 				expect(testView.$(processDataSel).hasClass('disabled')).toBe(true);
 			});
+
+			it('Expects that if the steop is CHOOSE_DATA_VARIABLES_STEP and the hasSelectedVariables is changed to true, the process data button in enabled', function() {
+				var processDataBtn = testView.$(processDataSel);
+				testModel.set('location', {latitude: 43.0, longitude : -100.0});
+				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
+
+				expect(processDataBtn.hasClass('disabled')).toBe(true);
+
+				testModel.set('hasSelectedVariables', true);
+
+				expect(processDataBtn.hasClass('disabled')).toBe(false);
+			});
 		});
 	});
 });

--- a/src/test/js/views/PrecipDataViewSpec.js
+++ b/src/test/js/views/PrecipDataViewSpec.js
@@ -33,7 +33,7 @@ define([
 				$el : $testDiv,
 				model : testModel,
 				distanceToProjectLocation : '1.345'
-			})
+			});
 		});
 
 		afterEach(function() {

--- a/src/test/js/views/PrecipDataViewSpec.js
+++ b/src/test/js/views/PrecipDataViewSpec.js
@@ -5,10 +5,11 @@ define([
 	'jquery',
 	'moment',
 	'backbone',
+	'models/PrecipitationVariableCollection',
 	'views/PrecipDataView'
-], function($, moment, Backbone, PrecipDataView) {
+], function($, moment, Backbone, PrecipitationVariableCollection, PrecipDataView) {
 
-	describe('views/PrecipDataView', function() {
+	fdescribe('views/PrecipDataView', function() {
 		var testView;
 		var testModel;
 		var $testDiv;
@@ -19,10 +20,14 @@ define([
 			testModel = new Backbone.Model({
 				lat : '43.1346',
 				lon : '-100.2121',
-				x : '514',
-				y : '720',
-				startDate : moment('2002-01-01', 'YYYY-MM-DD'),
-				endDate : moment('2016-04-18', 'YYYY-MM-DD')
+				variables : new PrecipitationVariableCollection([
+					{
+						x : '514',
+						y : '720',
+						startDate : moment('2002-01-01', 'YYYY-MM-DD'),
+						endDate : moment('2016-04-18', 'YYYY-MM-DD')
+					}
+				])
 			});
 			testView = new PrecipDataView({
 				$el : $testDiv,
@@ -57,7 +62,7 @@ define([
 		});
 
 		it('Expects that the checkbox is checked if the selected property is set to true in the model when the view is rendered', function() {
-			testModel.set('selected', true);
+			testModel.get('variables').at(0).set('selected', true);
 			testView.render();
 
 			expect(testView.$('input:checkbox').is(':checked')).toBe(true);
@@ -67,7 +72,7 @@ define([
 			testView.render();
 			testView.$('input:checkbox').trigger('click');
 
-			expect(testModel.get('selected')).toBe(true);
+			expect(testModel.get('variables').at(0).get('selected')).toBe(true);
 		});
 
 		it('Expects that if the checkbox is clicked twice, the selected property is set back to false', function() {
@@ -75,21 +80,22 @@ define([
 			testView.$('input:checkbox').trigger('click');
 			testView.$('input:checkbox').trigger('click');
 
-			expect(testModel.get('selected')).toBe(false);
+			expect(testModel.get('variables').at(0).get('selected')).toBe(false);
 		});
 
 		it('Expects that if the model\'s selected attribute is updated the variable checkbox reflects it\'s state', function() {
 			var $checkbox;
+			var variableModel = testModel.get('variables').at(0);
 			testView.render();
 			$checkbox = testView.$('input:checkbox');
-			testModel.set('selected', false);
+			variableModel.set('selected', false);
 
 			expect($checkbox.prop('checked')).toBe(false);
 
-			testModel.set('selected', true);
+			variableModel.set('selected', true);
 			expect($checkbox.prop('checked')).toBe(true);
 
-			testModel.unset('selected');
+			variableModel.unset('selected');
 			expect($checkbox.prop('checked')).toBe(false);
 		});
 	});

--- a/src/test/js/views/PrecipDataViewSpec.js
+++ b/src/test/js/views/PrecipDataViewSpec.js
@@ -9,7 +9,7 @@ define([
 	'views/PrecipDataView'
 ], function($, moment, Backbone, PrecipitationVariableCollection, PrecipDataView) {
 
-	fdescribe('views/PrecipDataView', function() {
+	describe('views/PrecipDataView', function() {
 		var testView;
 		var testModel;
 		var $testDiv;

--- a/src/test/js/views/VariableSummaryViewSpec.js
+++ b/src/test/js/views/VariableSummaryViewSpec.js
@@ -4,12 +4,13 @@
 define([
 	'jquery',
 	'underscore',
-	'backbone',
 	'moment',
 	'Config',
 	'models/WorkflowStateModel',
+	'models/PrecipitationVariableCollection',
+	'models/NWISVariableCollection',
 	'views/VariableSummaryView'
-], function($, _, Backbone, moment, Config, WorkflowStateModel, VariableSummaryView) {
+], function($, _, moment, Config, WorkflowStateModel, PrecipitationVariableCollection, NWISVariableCollection, VariableSummaryView) {
 	describe('views/VariableSummaryView', function() {
 		var testView;
 		var $testDiv;
@@ -64,10 +65,11 @@ define([
 				datasetCollections = testModel.get('datasetCollections');
 				testView.render.calls.reset();
 				datasetCollections[Config.PRECIP_DATASET].reset([
-					{x : '1', y : '2'}, {x : '2', y : '2'}
+					{variables : new PrecipitationVariableCollection([{x : '1', y : '2'}])},
+					{variables : new PrecipitationVariableCollection([{x : '2', y : '2'}])}
 				]);
 				datasetCollections[Config.NWIS_DATASET].reset([
-					{siteId : 'S1', variables : new Backbone.Collection([{name : 'V1'}, {name : 'V2'}])}
+					{siteId : 'S1', variables : new NWISVariableCollection([{name : 'V1'}, {name : 'V2'}])}
 				]);
 
 				expect(testView.render).toHaveBeenCalled();
@@ -87,11 +89,11 @@ define([
 				testModel.initializeDatasetCollections();
 				datasetCollections = testModel.get('datasetCollections');
 				datasetCollections[Config.PRECIP_DATASET].reset([
-					{x : '1', y : '2', lat : '43', lon : '-90', startDate : startDate, endDate : endDate},
-					{x : '2', y : '3', lat : '44', lon : '-91', startDate : startDate, endDate : endDate}
+					{lat : '43', lon : '-90', variables : new PrecipitationVariableCollection([{x : '1', y : '2', startDate : startDate, endDate : endDate}])},
+					{lat : '44', lon : '-91', variables : new PrecipitationVariableCollection([{x : '2', y : '3', startDate : startDate, endDate : endDate}])}
 				]);
 				datasetCollections[Config.NWIS_DATASET].reset([
-					{siteNo : 'S1', variables : new Backbone.Collection([
+					{siteNo : 'S1', variables : new NWISVariableCollection([
 							{name : 'V1', startDate : startDate, endDate : endDate},
 							{name : 'V2', startDate : startDate, endDate : endDate}])}
 				]);
@@ -109,8 +111,9 @@ define([
 			it('Expects that if a precip variable is selected the view is rendered with the appropriate context', function() {
 				var precipSelected;
 				var nwisSelected;
-				var precipModelToUpdate = datasetCollections[Config.PRECIP_DATASET].at(1)
-				precipModelToUpdate.set('selected', true);
+				var precipModelToUpdate = datasetCollections[Config.PRECIP_DATASET].at(1);
+				var precipVariableToUpdate = precipModelToUpdate.get('variables').at(0);
+				precipVariableToUpdate.set('selected', true);
 				precipSelected = _.find(testView.context.selectedDatasets, function(d) {
 					return d.datasetName === Config.PRECIP_DATASET;
 				});
@@ -123,7 +126,7 @@ define([
 				expect(precipSelected.variables.length).toBe(1);
 				expect(precipSelected.variables[0]).toEqual({
 					modelId : precipModelToUpdate.cid,
-					variableId : precipModelToUpdate.cid,
+					variableId : precipVariableToUpdate.cid,
 					siteId : '44.000, -91.000',
 					startDate : '2002-04-11',
 					endDate : '2006-11-23',
@@ -169,11 +172,11 @@ define([
 				testModel.initializeDatasetCollections();
 				datasetCollections = testModel.get('datasetCollections');
 				datasetCollections[Config.PRECIP_DATASET].reset([
-					{x : '1', y : '2', lat : '43', lon : '-90', startDate : startDate, endDate : endDate},
-					{x : '2', y : '3', lat : '44', lon : '-91', startDate : startDate, endDate : endDate, selected: true}
+					{lat : '43', lon : '-90', variables : new PrecipitationVariableCollection([{x : '1', y : '2', startDate : startDate, endDate : endDate}])},
+					{lat : '44', lon : '-91', variables : new PrecipitationVariableCollection([{x : '2', y : '3', startDate : startDate, endDate : endDate, selected: true}])}
 				]);
 				datasetCollections[Config.NWIS_DATASET].reset([
-					{siteNo : 'S1', variables : new Backbone.Collection([
+					{siteNo : 'S1', variables : new NWISVariableCollection([
 							{name : 'V1', startDate : startDate, endDate : endDate, selected : true},
 							{name : 'V2', startDate : startDate, endDate : endDate}])}
 				]);
@@ -186,12 +189,12 @@ define([
 			});
 
 			it('Expects that clicking a variables remove button unselects that variable', function(){
-				var selectedPrecipModel = datasetCollections[Config.PRECIP_DATASET].at(1);
+				var selectedPrecipVariableModel = datasetCollections[Config.PRECIP_DATASET].at(1).get('variables').at(0);
 				var selectedNWISVariableModel = datasetCollections[Config.NWIS_DATASET].at(0).get('variables').at(0);
 
-				testView.$('button[data-variable-id="' + selectedPrecipModel.cid + '"]').trigger('click');
+				testView.$('button[data-variable-id="' + selectedPrecipVariableModel.cid + '"]').trigger('click');
 
-				expect(selectedPrecipModel.get('selected')).toBe(false);
+				expect(selectedPrecipVariableModel.get('selected')).toBe(false);
 
 				testView.$('button[data-variable-id="' + selectedNWISVariableModel.cid + '"]').trigger('click');
 


### PR DESCRIPTION
Implemented the ability to actually send the process data call to enddat-services and return raw data for the selected variables. Made defaults for the necessary parameters to the call.

As part of this work, I refactored the site collections to store their variables in a BaseVariableCollection. Each dataset will extend the this collection and redefined the getSelectedUrlParam function to return the url parameters to be used for the selected variables. This means for the PrecipitationCollection, the variables collection will only contain a single variable. Also needed to add a call to return the precipitation service dds in order to determine what the current timeInterval parameter is.

I updated the navigation to allow the Process Data button to be clicked. 

Note the ProcessDataView has no tests. It has minimal functionality and will change dramatically as we more fully flesh out the Process Data step so I intentionally did not write any tests.