### PR TITLE
Enddat 224

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ npm-debug.logcoverage.xml
 
 /nb-configuration.xml
 .DS_Store
+/nbactions.xml

--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,8 @@
     "loglevel": "1.4.0",
     "backbone.stickit": "0.9.2",
     "moment": "2.12.0",
-    "eonasdan-bootstrap-datetimepicker": "4.17.37"
+    "eonasdan-bootstrap-datetimepicker": "4.17.37",
+    "leaflet-draw": "0.3.0"
   },
   "resolutions": {
     "underscore": "1.8.3",

--- a/src/main/webapp/dataDiscovery.jsp
+++ b/src/main/webapp/dataDiscovery.jsp
@@ -6,6 +6,7 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<link rel="stylesheet" type="text/css" href="<%=baseUrl%>bower_components/select2/dist/css/select2.min.css" />
 		<link rel="stylesheet" type="text/css" href="<%=baseUrl%>bower_components/leaflet/dist/leaflet.css" />
+		<link rel="stylesheet" type="text/css" href="<%=baseUrl%>bower_components/leaflet-draw/dist/leaflet.draw.css" />
 		<link rel="stylesheet" type="text/css" href="css/custom.css" />
 	</head>
 	<body>
@@ -56,6 +57,7 @@
 					"hbs" : '<%=baseUrl%>bower_components/requirejs-hbs/hbs',
 					'leaflet' : '<%=baseUrl%>bower_components/leaflet/dist/leaflet',
 					'leaflet-providers' : '<%=baseUrl%>bower_components/leaflet-providers/leaflet-providers',
+					'leaflet-draw' : '<%=baseUrl%>bower_components/leaflet-draw/dist/leaflet.draw',
 					'loglevel' : '<%=baseUrl%>bower_components/loglevel/dist/loglevel<%= development ? "" : ".min"%>',
 					'backbone.stickit' : '<%=baseUrl%>bower_components/backbone.stickit/backbone.stickit',
 					'moment' : '<%=baseUrl%>bower_components/moment/<%=development ? "" : "min/"%>moment<%=development ? "" : ".min"%>',
@@ -66,6 +68,7 @@
 					'leaflet' : {
 						exports: 'L'
 					},
+					'leaflet-draw' : ['leaflet'],
 					'leaflet-providers' : ['leaflet'],
 					'backbone' : {
 						deps : ['jquery', 'underscore'],

--- a/src/main/webapp/js/Config.js
+++ b/src/main/webapp/js/Config.js
@@ -26,7 +26,7 @@ define([], function() {
 			}
 		},
 
-		PROJ_LOC_STEP : 'specifyProjectLocation',
+		SPECIFY_AOI_STEP : 'specifyAOI',
 		CHOOSE_DATA_FILTERS_STEP : 'chooseDataFilters',
 		CHOOSE_DATA_VARIABLES_STEP : 'chooseDataVariables',
 		PROCESS_DATA_STEP :'processData',

--- a/src/main/webapp/js/controller/AppRouter.js
+++ b/src/main/webapp/js/controller/AppRouter.js
@@ -16,7 +16,7 @@ define([
 	var appRouter = Backbone.Router.extend({
 		routes: {
 			'': 'specifyProjectLocationState',
-			'lat/:lat/lng/:lng(/radius/:radius)(/startdate/:startDate)(/enddate/:endDate)(/dataset/*datasets)' : 'chooseDataState'
+			'lat/:lat/lng/:lng/radius/:radius(/startdate/:startDate)(/enddate/:endDate)(/dataset/*datasets)' : 'chooseDataState'
 		},
 
 		initialize : function(options) {

--- a/src/main/webapp/js/controller/AppRouter.js
+++ b/src/main/webapp/js/controller/AppRouter.js
@@ -54,7 +54,7 @@ define([
 		},
 
 		specifyProjectLocationState: function () {
-			this.workflowState.set('step', Config.PROJ_LOC_STEP);
+			this.workflowState.set('step', Config.SPECIFY_AOI_STEP);
 			this.createView(DataDiscoveryView, {
 				model : this.workflowState
 			}).render();

--- a/src/main/webapp/js/controller/AppRouter.js
+++ b/src/main/webapp/js/controller/AppRouter.js
@@ -11,13 +11,12 @@ define([
 ], function ($, Backbone, log, moment, Config, WorkflowStateModel, DataDiscoveryView) {
 	"use strict";
 
-	var DATE_FORMAT = 'DMMMYYYY';
-
 	var appRouter = Backbone.Router.extend({
 		routes: {
 			'': 'specifyProjectLocationState',
-			'lat/:lat/lng/:lng/radius/:radius(/startdate/:startDate)(/enddate/:endDate)(/dataset/*datasets)' : 'chooseDataState'
-		},
+			'lat/:lat/lng/:lng/radius/:radius(/startdate/:startDate)(/enddate/:endDate)(/dataset/*datasets)' : 'chooseDataStateProjLoc',
+			'aoiBbox/:bbox(/startdate/:startDate)(/enddate/:endDate)(/dataset/*datasets)' : 'chooseDataStateAOIBox'
+	},
 
 		initialize : function(options) {
 			Backbone.Router.prototype.initialize.apply(this, arguments);
@@ -60,20 +59,40 @@ define([
 			}).render();
 		},
 
-		chooseDataState : function(lat, lng, radius, startDate, endDate, datasets) {
+		chooseDataState : function(aoi, startDate, endDate, datasets) {
 			this.workflowState.initializeDatasetCollections();
+			this.workflowState.get('aoi').set(aoi);
 			this.workflowState.set({
-				'location' : {latitude : lat, longitude : lng},
-				'radius' : radius,
-				'startDate' : (startDate) ? moment(startDate, DATE_FORMAT) : '',
-				'endDate' : (endDate) ? moment(endDate, DATE_FORMAT) : ''
+				'startDate' : (startDate) ? moment(startDate, Config.DATE_FORMAT_URL) : '',
+				'endDate' : (endDate) ? moment(endDate, Config.DATE_FORMAT_URL) : ''
 			});
 			this.workflowState.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 			this.createView(DataDiscoveryView, {
 				model : this.workflowState
 			}).render();
 			this.workflowState.set('datasets', datasets ? datasets.split('/') : []);
+		},
 
+		chooseDataStateProjLoc : function(lat, lng, radius, startDate, endDate, datasets) {
+			var aoi = {
+				latitude : lat,
+				longitude : lng,
+				radius : radius
+			};
+			this.chooseDataState(aoi, startDate, endDate, datasets);
+		},
+
+		chooseDataStateAOIBox : function(bboxStr, startDate, endDate, datasets) {
+			var bboxArr = bboxStr.split(',');
+			var aoi = {
+				aoiBox : {
+					south : parseFloat(bboxArr[0]),
+					west : parseFloat(bboxArr[1]),
+					north : parseFloat(bboxArr[2]),
+					east : parseFloat(bboxArr[3])
+				}
+			};
+			this.chooseDataState(aoi, startDate, endDate, datasets);
 		}
 	});
 

--- a/src/main/webapp/js/hb_templates/aoiBox.hbs
+++ b/src/main/webapp/js/hb_templates/aoiBox.hbs
@@ -6,9 +6,9 @@
 </div>
 <div class="form-group">
 	<label>Southwest</label>
-	<input type="text" readonly class="form-control" value="{{south}}, {{west}}" />
+	<input type="text" readonly class="form-control" {{#if south}}value="{{south}}, {{west}}"{{/if}} />
 </div>
 <div class="form-group">
 	<label>Northeast</label>
-	<input type="text" readonly class="form-control" value="{{north}}, {{east}}" />
+	<input type="text" readonly class="form-control" {{#if north}}value="{{north}}, {{east}}"{{/if}} />
 </div>

--- a/src/main/webapp/js/hb_templates/aoiBox.hbs
+++ b/src/main/webapp/js/hb_templates/aoiBox.hbs
@@ -1,0 +1,22 @@
+<div class="hint-div">
+	<em>
+		Use the controls on the map below the Legend to draw a rectangle and to update the rectangle.
+		This will be the area of interest for data discovery.
+	</em>
+</div>
+<div class="form-group">
+	<label>South</label>
+	<input type="text" readonly class="form-control" value="{{south}}" />
+</div>
+<div class="form-group">
+	<label>West</label>
+	<input type="text" readonly class="form-control" value="{{west}}" />
+</div>
+<div class="form-group">
+	<label>North</label>
+	<input type="text" readonly class="form-control" value="{{north}}" />
+</div>
+<div class="form-group">
+	<label>East</label>
+	<input type="text" readonly class="form-control" value="{{east}}" />
+</div>

--- a/src/main/webapp/js/hb_templates/aoiBox.hbs
+++ b/src/main/webapp/js/hb_templates/aoiBox.hbs
@@ -5,18 +5,10 @@
 	</em>
 </div>
 <div class="form-group">
-	<label>South</label>
-	<input type="text" readonly class="form-control" value="{{south}}" />
+	<label>Southwest</label>
+	<input type="text" readonly class="form-control" value="{{south}}, {{west}}" />
 </div>
 <div class="form-group">
-	<label>West</label>
-	<input type="text" readonly class="form-control" value="{{west}}" />
-</div>
-<div class="form-group">
-	<label>North</label>
-	<input type="text" readonly class="form-control" value="{{north}}" />
-</div>
-<div class="form-group">
-	<label>East</label>
-	<input type="text" readonly class="form-control" value="{{east}}" />
+	<label>Northeast</label>
+	<input type="text" readonly class="form-control" value="{{north}}, {{east}}" />
 </div>

--- a/src/main/webapp/js/hb_templates/aoiSelect.hbs
+++ b/src/main/webapp/js/hb_templates/aoiSelect.hbs
@@ -1,0 +1,9 @@
+<div class="well well-lg">
+	<h2>How do you want to describe your area of interest</h2>
+	<div class="form-group">
+		<select class="form-control">
+			<option value="location">Pick project location and radius</option>
+			<option value="aoiBox">Create a box</option>
+		</select>
+	</div>
+</div>

--- a/src/main/webapp/js/hb_templates/aoiSelect.hbs
+++ b/src/main/webapp/js/hb_templates/aoiSelect.hbs
@@ -1,9 +1,0 @@
-<div class="well well-lg">
-	<h2>How do you want to describe your area of interest</h2>
-	<div class="form-group">
-		<select class="form-control">
-			<option value="location">Pick project location and radius</option>
-			<option value="aoiBox">Create a box</option>
-		</select>
-	</div>
-</div>

--- a/src/main/webapp/js/hb_templates/choose.hbs
+++ b/src/main/webapp/js/hb_templates/choose.hbs
@@ -1,7 +1,7 @@
 <div>
 	<div class="form-group">
 		<label for="datasets-select">Datasets</label>
-		<select id="datasets-select" class="form-control" multiple>
+		<select id="datasets-select" class="form-control" multiple style="width: 100%">
 			<option value="NWIS">USGS Time Series (NWIS)</option>
 			<option value="PRECIP">1 Hr National Precipitation Grid Points</option>
 			<option value="ACIS">Applied Climate Information System</option>

--- a/src/main/webapp/js/hb_templates/choose.hbs
+++ b/src/main/webapp/js/hb_templates/choose.hbs
@@ -7,10 +7,6 @@
 			<option value="ACIS">Applied Climate Information System</option>
 		</select>
 	</div>
-	<div class="form-group">
-		<label for="radius">Radius</label>
-		<input id="radius" class="form-control" type="number" min="0" max="500" step="any" value="{{radius}}"/>
-	</div>
 	<div>
 		<div class="form-group">
 			<label>Date Range (optional)</label>

--- a/src/main/webapp/js/hb_templates/dataDiscovery.hbs
+++ b/src/main/webapp/js/hb_templates/dataDiscovery.hbs
@@ -1,5 +1,15 @@
 <div class="workflow-nav"></div>
 <div class="workflow-content-container">
+	<div class="well well-lg workflow-start-container collapse">
+		<h2>How do you want to describe your area of interest</h2>
+		<div class="form-group">
+			<select class="form-control">
+				<option value=""></option>
+				<option value="location">Pick project location and radius</option>
+				<option value="aoiBox">Create a box</option>
+			</select>
+		</div>
+	</div>
 	<div class="row entry-panels-div">
 		<div class="location-panel"></div>
 		<div class="choose-panel"></div>

--- a/src/main/webapp/js/hb_templates/location.hbs
+++ b/src/main/webapp/js/hb_templates/location.hbs
@@ -10,4 +10,8 @@
 		<input id="longitude" class="form-control" type="number" min="-180.0" max="180.0" step="any" value="{{longitude}}"/>
 	</div>
 	<button class="btn btn-default btn-sm use-location-btn" type="button">Use my location</button>
+	<div class="form-group">
+		<label for="radius">Radius</label>
+		<input id="radius" class="form-control" type="number" min="0" max="500" step="any" value="{{radius}}"/>
+	</div>
 </div>

--- a/src/main/webapp/js/hb_templates/workflowNav.hbs
+++ b/src/main/webapp/js/hb_templates/workflowNav.hbs
@@ -10,7 +10,7 @@
 	</div>
 	<div class="collapse navbar-collapse" id="workflow-nav-collapse">
 		 <ul class="nav navbar-nav">
-			<li class="nav-project-loc" role="presentation"><a  href="#">Specify Project Location<i class="fa fa-map-marker fa-4x"></i></a></li>
+			<li class="nav-specify-aoi" role="presentation"><a  href="#">Specify Project AOI<i class="fa fa-map-marker fa-4x"></i></a></li>
 			<li class="nav-choose-data" role="presentation"><a href="#">Choose Data<i>
 				<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 					viewBox="0 0 290 211" enable-background="new 0 0 290 211" xml:space="preserve">
@@ -35,7 +35,7 @@
 				<h4 class="modal-title" id="nav-warning-title">Navigation Warning</h4>
 			</div>
 			<div class="modal-body">
-				Are you sure you want to go back to Specify Project Location step? All data will be
+				Are you sure you want to go back to Specify Project AOI step? All data will be
 				cleared.
 			</div>
 			<div class="modal-footer">

--- a/src/main/webapp/js/models/AOIModel.js
+++ b/src/main/webapp/js/models/AOIModel.js
@@ -1,0 +1,48 @@
+/* jslint browser: true */
+
+define([
+	'backbone',
+	'utils/geoSpatialUtils'
+], function(Backbone, geoSpatialUtils) {
+	"use strict";
+
+	var model = Backbone.Model.extend({
+
+		usingProjectLocation : function() {
+			return this.has('latitude') && this.has('longitude') && this.has('radius');
+		},
+
+		usingAOIBox : function() {
+			return this.has('aoiBox')
+		},
+
+		hasValidAOI : function() {
+			var result = false;
+			if (this.usingProjectLocation()) {
+				result =  ((this.attributes.latitude) && (this.attributes.longitude) && (this.attributes.radius)) ? true : false;
+			}
+			else if (this.usingAOIBox()) {
+				result = (this.attributes.aoiBox) ? true : false;
+			}
+			return result;
+		},
+
+		getBoundingBox : function() {
+			var result = undefined;
+			if (this.usingProjectLocation()) {
+				result = geoSpatialUtils.getBoundingBox(
+					this.attributes.latitude,
+					this.attributes.longitude,
+					this.attributes.radius
+				);
+			}
+			else if (this.usingAOIBox()) {
+				result = this.attributes.aoiBox;
+			}
+			return result;
+		}
+	});
+
+	return model;
+});
+

--- a/src/main/webapp/js/models/AOIModel.js
+++ b/src/main/webapp/js/models/AOIModel.js
@@ -30,11 +30,13 @@ define([
 		getBoundingBox : function() {
 			var result = undefined;
 			if (this.usingProjectLocation()) {
-				result = geoSpatialUtils.getBoundingBox(
-					this.attributes.latitude,
-					this.attributes.longitude,
-					this.attributes.radius
-				);
+				if ((this.attributes.latitude) && (this.attributes.longitude) && (this.attributes.radius)) {
+					result = geoSpatialUtils.getBoundingBox(
+						this.attributes.latitude,
+						this.attributes.longitude,
+						this.attributes.radius
+					);
+				}
 			}
 			else if (this.usingAOIBox()) {
 				result = this.attributes.aoiBox;

--- a/src/main/webapp/js/models/AOIModel.js
+++ b/src/main/webapp/js/models/AOIModel.js
@@ -9,14 +9,23 @@ define([
 
 	var model = Backbone.Model.extend({
 
+		/*
+		 * @return Boolean - true if the AOI should be defined using a location and radius
+		 */
 		usingProjectLocation : function() {
 			return this.has('latitude') && this.has('longitude') && this.has('radius');
 		},
 
+		/*
+		 * @return Boolean - true if the AOI should be defined by a bounding box
+		 */
 		usingAOIBox : function() {
 			return this.has('aoiBox');
 		},
 
+		/*
+		 * @return Boolean - true if the area of interest is fully defined
+		 */
 		hasValidAOI : function() {
 			var result = false;
 			if (this.usingProjectLocation()) {
@@ -28,6 +37,10 @@ define([
 			return result;
 		},
 
+		/*
+		 * @return {Object with south, west, north, east parameters} - Returns the bounding box represented by the model.
+		 *		Returns undefined if the model does not contain a fully defined area of interset.
+		 */
 		getBoundingBox : function() {
 			var result = undefined;
 			if (this.usingProjectLocation()) {

--- a/src/main/webapp/js/models/AOIModel.js
+++ b/src/main/webapp/js/models/AOIModel.js
@@ -7,6 +7,13 @@ define([
 ], function(_, Backbone, geoSpatialUtils) {
 	"use strict";
 
+	/*
+	 * This model will represent the area of interest that will be used in the application. The AOI
+	 * can be defined in several ways. Currently, it can be a model with latitude, longitude, and radius
+	 * properties or an aoiBox property that contains a bounding box object. In general, unless a view is
+	 * setting or displaying model properties, the user should use the methods defined here to access
+	 * information.
+	 */
 	var model = Backbone.Model.extend({
 
 		/*

--- a/src/main/webapp/js/models/AOIModel.js
+++ b/src/main/webapp/js/models/AOIModel.js
@@ -1,9 +1,10 @@
 /* jslint browser: true */
 
 define([
+	'underscore',
 	'backbone',
 	'utils/geoSpatialUtils'
-], function(Backbone, geoSpatialUtils) {
+], function(_, Backbone, geoSpatialUtils) {
 	"use strict";
 
 	var model = Backbone.Model.extend({
@@ -13,7 +14,7 @@ define([
 		},
 
 		usingAOIBox : function() {
-			return this.has('aoiBox')
+			return this.has('aoiBox');
 		},
 
 		hasValidAOI : function() {
@@ -22,7 +23,7 @@ define([
 				result =  ((this.attributes.latitude) && (this.attributes.longitude) && (this.attributes.radius)) ? true : false;
 			}
 			else if (this.usingAOIBox()) {
-				result = (this.attributes.aoiBox) ? true : false;
+				result = !_.isEmpty(this.attributes.aoiBox);
 			}
 			return result;
 		},
@@ -39,7 +40,9 @@ define([
 				}
 			}
 			else if (this.usingAOIBox()) {
-				result = this.attributes.aoiBox;
+				if (!_.isEmpty(this.attributes.aoiBox)) {
+					result = this.attributes.aoiBox;
+				}
 			}
 			return result;
 		}

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -27,7 +27,7 @@ define([
 			return {
 				step : 'unknown',
 				hasSelectedVariables : false,
-				aoi : new AOIModel
+				aoi : new AOIModel()
 			};
 		},
 

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -14,7 +14,6 @@ define([
 ], function(_, $, moment, Backbone, Config, geoSpatialUtils, NWISCollection, PrecipitationCollection, ACISCollection, AOIModel) {
 	"use strict";
 
-	var DEFAULT_CHOOSE_DATA_RADIUS = 2;
 	var DEFAULT_CHOSEN_DATASETS = ['NWIS'];
 
 	// Defaults for processing step
@@ -132,11 +131,7 @@ define([
 					this.unset('startDate');
 					this.unset('endDate');
 					//TODO add code to allow switching between project location and aoi box.
-					this.get('aoi').set({
-						'latitude' : '',
-						'longitude' : '',
-						'radius' : DEFAULT_CHOOSE_DATA_RADIUS
-					});
+					this.get('aoi').unset();
 					break;
 
 				case Config.CHOOSE_DATA_FILTERS_STEP:

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -6,12 +6,11 @@ define([
 	'moment',
 	'backbone',
 	'Config',
-	'utils/geoSpatialUtils',
 	'models/NWISCollection',
 	'models/PrecipitationCollection',
 	'models/ACISCollection',
 	'models/AOIModel'
-], function(_, $, moment, Backbone, Config, geoSpatialUtils, NWISCollection, PrecipitationCollection, ACISCollection, AOIModel) {
+], function(_, $, moment, Backbone, Config, NWISCollection, PrecipitationCollection, ACISCollection, AOIModel) {
 	"use strict";
 
 	var DEFAULT_CHOSEN_DATASETS = ['NWIS'];

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -130,7 +130,7 @@ define([
 					this.unset('startDate');
 					this.unset('endDate');
 					//TODO add code to allow switching between project location and aoi box.
-					this.get('aoi').unset();
+					this.get('aoi').clear();
 					break;
 
 				case Config.CHOOSE_DATA_FILTERS_STEP:

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -129,6 +129,8 @@ define([
 						});
 					};
 					this.unset('datasets');
+					this.unset('startDate');
+					this.unset('endDate');
 					//TODO add code to allow switching between project location and aoi box.
 					this.get('aoi').set({
 						'latitude' : '',

--- a/src/main/webapp/js/models/WorkflowStateModel.js
+++ b/src/main/webapp/js/models/WorkflowStateModel.js
@@ -9,8 +9,9 @@ define([
 	'utils/geoSpatialUtils',
 	'models/NWISCollection',
 	'models/PrecipitationCollection',
-	'models/ACISCollection'
-], function(_, $, moment, Backbone, Config, geoSpatialUtils, NWISCollection, PrecipitationCollection, ACISCollection) {
+	'models/ACISCollection',
+	'models/AOIModel'
+], function(_, $, moment, Backbone, Config, geoSpatialUtils, NWISCollection, PrecipitationCollection, ACISCollection, AOIModel) {
 	"use strict";
 
 	var DEFAULT_CHOOSE_DATA_RADIUS = 2;
@@ -27,7 +28,8 @@ define([
 		defaults : function() {
 			return {
 				step : 'unknown',
-				hasSelectedVariables : false
+				hasSelectedVariables : false,
+				aoi : new AOIModel
 			};
 		},
 
@@ -39,7 +41,7 @@ define([
 
 		/*
 		 * Instantiates the datasetModels and sets up the model event listeners which will fetch new
-		 * dataset model information if the datasetCollections have not yet been instantiated. If they
+		 * dataset model information when needed. If they
 		 * have already been created, empty the contents of the collections
 		 */
 		initializeDatasetCollections : function() {
@@ -56,38 +58,10 @@ define([
 					[Config.ACIS_DATASET, new ACISCollection()]
 				]);
 				this.set('datasetCollections', datasetCollections);
-				this.on('change:radius', this.updateDatasetCollections, this);
-				this.on('change:location', this.updateDatasetCollections, this);
+
+				this.get('aoi').on('change', this.changeAOI, this);
 				this.on('change:datasets', this.updateDatasetCollections, this);
 			}
-		},
-
-		/*
-		 * @returns {Boolean} - Returns true if the model contains a location property that contains
-		 * an object with non empty latitude and longitude properties
-		 */
-		hasValidLocation : function() {
-			return (this.has('location') &&
-				((this.attributes.location.latitude) ? true : false) &&
-				((this.attributes.location.longitude) ? true : false));
-
-		},
-
-		/*
-		 * Returns the bounding box as an object with west, east, north, and south properties.
-		 * Return undefined if the model's properties do not contain a valid bounding box
-		 * @return {Object} - has west, east, north, south properties or undefined
-		 */
-		getBoundingBox : function() {
-			var result = undefined;
-			if ((this.attributes.radius) && this.hasValidLocation()) {
-				result = geoSpatialUtils.getBoundingBox(
-					this.attributes.location.latitude,
-					this.attributes.location.longitude,
-					this.attributes.radius
-				);
-			}
-			return result;
 		},
 
 		/*
@@ -107,37 +81,37 @@ define([
 		 * Model event handlers
 		 */
 
-		 /*  If the radius or location has changed, all datasets are either fetched (if chosen) or cleared.
-		  *  If the dataset has changed, then the previous datasets or compared to the current. Datasets added to the
+		 /*
+		  *  The previous datasets are compared to the current. Datasets added to the
 		  *  current datasets are fetched and datasets removed from the current datasets are cleared.
 		  */
 		updateDatasetCollections : function() {
 			var previousAttributes = this.previousAttributes();
-			var boundingBox = this.getBoundingBox();
+			var boundingBox = this.get('aoi').getBoundingBox();
 			var chosenDatasets = this.has('datasets') ? this.get('datasets') : [];
 			var previousChosenDatasets = _.has(previousAttributes, 'datasets') ? previousAttributes.datasets : [];
 
-			var datasetsToFetch = {};
-			var datasetsToClear = {};
-
-			if (this.hasChanged('radius') || this.hasChanged('location')) {
-				//Need to fetch/clear all dataset collections
-				if (boundingBox) {
-					datasetsToFetch = chosenDatasets;
-					datasetsToClear = _.difference(Config.ALL_DATASETS, chosenDatasets);
-				}
-				else {
-					datasetsToClear = Config.ALL_DATASETS;
-				}
-			}
-			else {
-				//Update only datasets that have been added or removed from the chosen datasets
-				datasetsToFetch = _.difference(chosenDatasets, previousChosenDatasets);
-				datasetsToClear =  _.difference(previousChosenDatasets, chosenDatasets);
-			}
+			//Update only datasets that have been added or removed from the chosen datasets
+			var datasetsToFetch = _.difference(chosenDatasets, previousChosenDatasets);
+			var datasetsToClear =  _.difference(previousChosenDatasets, chosenDatasets);
 
 			this.fetchDatasets(datasetsToFetch, boundingBox);
 			this.clearDatasets(datasetsToClear);
+		},
+
+		/*
+		 * If the aoi property contains a model with a defined bounding box, then
+		 * fetch all chosen datasets. Otherwise clear all datasets.
+		 */
+		changeAOI : function() {
+			var boundingBox = this.get('aoi').getBoundingBox();
+			var chosenDatasets = this.has('datasets') ? this.get('datasets') : [];
+			if (boundingBox) {
+				this.fetchDatasets(chosenDatasets, boundingBox);
+			}
+			else {
+				this.clearDatasets(Config.ALL_DATASETS);
+			}
 		},
 
 		/*
@@ -148,24 +122,25 @@ define([
 			var outputDateRange = undefined;
 
 			switch(this.get('step')) {
-				case Config.PROJ_LOC_STEP:
+				case Config.SPECIFY_AOI_STEP:
 					if (this.has('datasetCollections')) {
 						_.each(this.get('datasetCollections'), function(collection) {
 							collection.reset();
 						});
 					};
 					this.unset('datasets');
-					this.unset('location');
-					this.unset('radius');
-					this.unset('startDate');
-					this.unset('endDate');
+					//TODO add code to allow switching between project location and aoi box.
+					this.get('aoi').set({
+						'latitude' : '',
+						'longitude' : '',
+						'radius' : DEFAULT_CHOOSE_DATA_RADIUS
+					});
 					break;
 
 				case Config.CHOOSE_DATA_FILTERS_STEP:
-					if (previousStep === Config.PROJ_LOC_STEP) {
+					if (previousStep === Config.SPECIFY_AOI_STEP) {
 						this.initializeDatasetCollections();
 						this.set('datasets', DEFAULT_CHOSEN_DATASETS);
-						this.set('radius', DEFAULT_CHOOSE_DATA_RADIUS);
 					}
 					break;
 

--- a/src/main/webapp/js/utils/LUtils.js
+++ b/src/main/webapp/js/utils/LUtils.js
@@ -19,6 +19,15 @@ define([
 			var northeast = L.latLng(bbox.north, bbox.east);
 			return L.latLngBounds(southwest, northeast);
 		};
+
+		self.getBbox = function(latLngBounds) {
+			return {
+				west : latLngBounds.getWest(),
+				south : latLngBounds.getSouth(),
+				east : latLngBounds.getEast(),
+				north : latLngBounds.getNorth()
+			};
+		};
 		return self;
 	})();
 

--- a/src/main/webapp/js/utils/LUtils.js
+++ b/src/main/webapp/js/utils/LUtils.js
@@ -13,6 +13,12 @@ define([
 		self.milesBetween = function(latlng1, latlng2) {
 			return latlng1.distanceTo(latlng2) * MILES_PER_METER;
 		};
+
+		self.getLatLngBounds = function(bbox) {
+			var southwest = L.latLng(bbox.south, bbox.west);
+			var northeast = L.latLng(bbox.north, bbox.east);
+			return L.latLngBounds(southwest, northeast);
+		};
 		return self;
 	})();
 

--- a/src/main/webapp/js/views/AOIBoxView.js
+++ b/src/main/webapp/js/views/AOIBoxView.js
@@ -1,0 +1,42 @@
+/* jslint browser: true */
+
+define([
+	'views/BaseCollapsiblePanelView',
+	'hbs!hb_templates/aoiBox'
+], function(BaseCollapsiblePanelView, hbTemplate) {
+	"use strict";
+
+	/*
+	 * @constructs
+	 * @param {Object} options
+	 *		@prop {AOIModel} model
+	 *		@prop {Jquery el or select} el
+	 *		@prop {Boolean} opened - Set to true if the panel should initially be open
+	 */
+	var view = BaseCollapsiblePanelView.extend({
+		template : hbTemplate,
+
+		panelHeading : 'Specify AOI Box',
+		panelBodyId : 'specify-aoi-box-panel-body',
+
+		initialize : function(options) {
+			BaseCollapsiblePanelView.prototype.initialize.apply(this, arguments);
+			this.listenTo(this.model, 'change', this.updatePanelContents);
+		},
+
+		render : function() {
+			this.context = this.model.attributes.aoiBox;
+			BaseCollapsiblePanelView.prototype.render.apply(this, arguments);
+			return this;
+		},
+
+		updatePanelContents : function() {
+			//Don't want to re-render the whole panel just the contents
+			this.$('.panel-body').html(this.template(this.model.attributes.aoiBox));
+		}
+	});
+
+	return view;
+});
+
+

--- a/src/main/webapp/js/views/ChooseView.js
+++ b/src/main/webapp/js/views/ChooseView.js
@@ -6,11 +6,10 @@ define([
 	'select2',
 	'moment',
 	'bootstrap-datetimepicker',
-	'backbone.stickit',
 	'Config',
 	'views/BaseCollapsiblePanelView',
 	'hbs!hb_templates/choose'
-], function(_, $, select2, moment, datetimepicker, stickit, Config, BaseCollapsiblePanelView, hbTemplate) {
+], function(_, $, select2, moment, datetimepicker, Config, BaseCollapsiblePanelView, hbTemplate) {
 	"use strict";
 
 	/*
@@ -34,19 +33,10 @@ define([
 			'dp.change #end-date-div' : 'changeEndDate'
 		},
 
-		bindings : {
-			'#radius' : {
-				observe : 'radius',
-				events : ['change']
-			}
-		},
-
-
 		render : function() {
 			var now = new Date();
 
 			BaseCollapsiblePanelView.prototype.render.apply(this, arguments);
-			this.stickit();
 
 			//Set up date pickers
 			this.$('#start-date-div').datetimepicker({

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -18,6 +18,8 @@ define([
 		VariableSummaryView, ProcessDataView, hbTemplate) {
 	"use strict";
 
+	var DEFAULT_RADIUS = 2;
+
 	var NAVVIEW_SELECTOR = '.workflow-nav';
 	var LOCATION_SELECTOR = '.location-panel';
 	var CHOOSE_SELECTOR = '.choose-panel';
@@ -256,9 +258,15 @@ define([
 
 		selectAOIDefinition : function(ev) {
 			var kind = $(ev.currentTarget).val();
+			var aoiModel = this.model.get('aoi');
 			this.$('.workflow-start-container').removeClass('in');
 			switch(kind) {
 				case 'location':
+					aoiModel.set({
+						latitude : '',
+						longitude : '',
+						radius : DEFAULT_RADIUS
+					});
 					if (!this.locationView) {
 						this.locationView = new LocationView({
 							el : $utils.createDivInContainer(this.$(LOCATION_SELECTOR)),
@@ -281,6 +289,17 @@ define([
 					break;
 
 				case 'aoiBox':
+					aoiModel.set({
+						aoiBox : {}
+					});
+					if (!this.mapView) {
+						this.mapView = new MapView({
+							el : $utils.createDivInContainer(this.$(MAPVIEW_SELECTOR)),
+							mapDivId : 'map-div',
+							model : this.model
+						});
+						this.mapView.render();
+					}
 					break;
 			}
 		}

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -132,18 +132,20 @@ define([
 						if (aoiModel.usingProjectLocation()) {
 							this.aoiView = new LocationView({
 								el : $utils.createDivInContainer(this.$(LOCATION_SELECTOR)),
-								model : model.get('aoi'),
+								model : aoiModel,
 								opened : true
 							});
 						}
 						else if (aoiModel.usingAOIBox()) {
 							this.aoiView = new AOIBoxView({
 								el : $utils.createDivInContainer(this.$(LOCATION_SELECTOR)),
-								model : model.get('aoi'),
+								model : aoiModel,
 								opened : true
 							});
 						}
-						this.aoiView.render();
+						if (this.aoiView) {
+							this.aoiView.render();
+						}
 					}
 					if (!this.mapView) {
 						this.mapView = new MapView({

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -140,7 +140,7 @@ define([
 					if (!this.locationView) {
 						this.locationView = new LocationView({
 							el : $utils.createDivInContainer(this.$(LOCATION_SELECTOR)),
-							model : model,
+							model : model.get('aoi'),
 							opened : true
 						});
 						this.locationView.render();

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -27,8 +27,19 @@ define([
 	var ALERTVIEW_SELECTOR = '.alert-container';
 	var LOADING_SELECTOR = '.loading-indicator';
 
+	var removeSubView = function(view) {
+		if (view) {
+			view.remove();
+		}
+		return undefined;
+	};
+
 	var view = BaseView.extend({
 		template: hbTemplate,
+
+		events : {
+			'change .workflow-start-container select' : 'selectAOIDefinition'
+		},
 
 		/*
 		 * @constructs
@@ -102,38 +113,14 @@ define([
 			this.alertView.closeAlert();
 			switch(step) {
 				case Config.SPECIFY_AOI_STEP:
-					if (!this.locationView) {
-						this.locationView = new LocationView({
-							el : $utils.createDivInContainer(this.$(LOCATION_SELECTOR)),
-							model : model.get('aoi'),
-							opened : true
-						});
-						this.locationView.render();
-					}
-					else {
-						this.locationView.expand();
-					}
-					if (!this.mapView) {
-						this.mapView = new MapView({
-							el : $utils.createDivInContainer(this.$(MAPVIEW_SELECTOR)),
-							mapDivId : 'map-div',
-							model : model
-						});
-						this.mapView.render();
-					}
+					this.$('.workflow-start-container select').val('');
+					this.$('.workflow-start-container').addClass('in');
+					this.locationView = removeSubView(this.locationView);
+					this.mapView = removeSubView(this.mapView);
+					this.chooseView = removeSubView(this.chooseView);
+					this.variableSummaryView = removeSubView(this.variableSummaryView);
+					this.processDataView = removeSubView(this.processDataView);
 
-					if (this.chooseView) {
-						this.chooseView.remove();
-						this.chooseView = undefined;
-					}
-					if (this.variableSummaryView) {
-						this.variableSummaryView.remove();
-						this.variableSummaryView = undefined;
-					}
-					if (this.processDataView) {
-						this.processDataView.remove();
-						this.processDataView = undefined;
-					}
 					break;
 
 				case Config.CHOOSE_DATA_FILTERS_STEP:
@@ -169,10 +156,7 @@ define([
 						});
 						this.variableSummaryView.render();
 					}
-					if (this.processDataView) {
-						this.processDataView.remove();
-						this.processDataView = undefined;
-					}
+					this.processDataView = removeSubView(this.processDataView);
 
 					this.variableSummaryView.expand();
 
@@ -206,19 +190,9 @@ define([
 						this.variableSummaryView.collapse();
 					}
 
-					if (this.locationView) {
-						this.locationView.remove();
-						this.locationView = undefined;
-					}
-					if (this.chooseView) {
-						this.chooseView.remove();
-						this.chooseView = undefined;
-					}
-					if (this.mapView) {
-						this.mapView.remove();
-						this.mapView = undefined;
-					}
-
+					this.locationView = removeSubView(this.locationView);
+					this.chooseView = removeSubView(this.chooseView);
+					this.mapView = removeSubView(this.mapView);
 			}
 		},
 
@@ -273,6 +247,41 @@ define([
 		closeAlert : function() {
 			if (null === this.model.get('datasets')) {
 				this.alertView.closeAlert();
+			}
+		},
+
+		/*
+		 * DOM Event Handlers
+		 */
+
+		selectAOIDefinition : function(ev) {
+			var kind = $(ev.currentTarget).val();
+			this.$('.workflow-start-container').removeClass('in');
+			switch(kind) {
+				case 'location':
+					if (!this.locationView) {
+						this.locationView = new LocationView({
+							el : $utils.createDivInContainer(this.$(LOCATION_SELECTOR)),
+							model : this.model.get('aoi'),
+							opened : true
+						});
+						this.locationView.render();
+					}
+					else {
+						this.locationView.expand();
+					}
+					if (!this.mapView) {
+						this.mapView = new MapView({
+							el : $utils.createDivInContainer(this.$(MAPVIEW_SELECTOR)),
+							mapDivId : 'map-div',
+							model : this.model
+						});
+						this.mapView.render();
+					}
+					break;
+
+				case 'aoiBox':
+					break;
 			}
 		}
 	});

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -178,7 +178,6 @@ define([
 				case Config.CHOOSE_DATA_VARIABLES_STEP:
 					// You can only get to this step from CHOOSE_DATA_FILTER_STEP
 					if (prevStep === Config.CHOOSE_DATA_FILTERS_STEP) {
-						if (this.location)
 						this.aoiView.collapse();
 						this.chooseView.collapse();
 					}
@@ -204,7 +203,7 @@ define([
 						this.variableSummaryView.collapse();
 					}
 
-					this.aoiView = removeSubView(this.locationView);
+					this.aoiView = removeSubView(this.aoiView);
 					this.chooseView = removeSubView(this.chooseView);
 					this.mapView = removeSubView(this.mapView);
 			}

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -101,11 +101,11 @@ define([
 
 			this.alertView.closeAlert();
 			switch(step) {
-				case Config.PROJ_LOC_STEP:
+				case Config.SPECIFY_AOI_STEP:
 					if (!this.locationView) {
 						this.locationView = new LocationView({
 							el : $utils.createDivInContainer(this.$(LOCATION_SELECTOR)),
-							model : model,
+							model : model.get('aoi'),
 							opened : true
 						});
 						this.locationView.render();
@@ -228,19 +228,28 @@ define([
 
 		_filterMsg : function() {
 			var state = this.model.attributes;
-			var latitude = (_.has(state, 'location') && _.has(state.location, 'latitude')) ? parseFloat(state.location.latitude).toFixed(3) : '';
-			var longitude = (_.has(state, 'location') && _.has(state.location, 'longitude')) ? parseFloat(state.location.longitude).toFixed(3) : '';
+			var aoi = state.aoi;
 
-			var radius = (state.radius) ? state.radius : '';
 			var startDate = (state.startDate) ? state.startDate.format(Config.DATE_FORMAT) : '';
 			var endDate = (state.endDate) ? state.endDate.format(Config.DATE_FORMAT) : '';
-			var chosenDatasets = (state.datasets) ? state.datasets : [];
-
 			var dateFilterMsg = (startDate && endDate) ? 'date filter from ' + startDate + ' to ' + endDate : 'no date filter';
 
+			var chosenDatasets = (state.datasets) ? state.datasets : [];
+
+			var aoiFragment = '';
+			if (aoi.usingProjectLocation()) {
+				var latitude = (aoi.attributes.latitude) ? parseFloat(aoi.attributes.latitude) : '';
+				var longitude = (aoi.attributes.longitude) ? parseFloat(aoi.attributes.longitude) : '';
+				var radius = (aoi.attributes.radius) ? aoi.attributes.radius : '';
+
+				aoiFragment = ' at location ' + latitude + ' ' + longitude + ', radius ' + radius + ' mi';
+			}
+			else if (aoi.usingAOIBox()) {
+				//TODO add code for aoi box
+			}
+
 			return 'Successfully fetched data of type(s): ' + chosenDatasets.join(', ') +
-				' at location ' + latitude + ' ' + longitude +
-				', radius ' + radius + ' mi and ' + dateFilterMsg;
+				aoiFragment + ' and ' + dateFilterMsg;
 		},
 
 		showSuccessfulFetchAlert : function() {

--- a/src/main/webapp/js/views/LocationView.js
+++ b/src/main/webapp/js/views/LocationView.js
@@ -28,60 +28,16 @@ define([
 
 		bindings : {
 			'#latitude' : {
-				observe : 'location',
-				onGet : function(value) {
-					if (value && _.has(value, 'latitude')) {
-						return value.latitude;
-					}
-					else {
-						return '';
-					}
-				},
-				events : ['change'],
-				onSet : function(value) {
-					var result;
-					if (this.model.has('location')) {
-						result = {
-							latitude : value,
-							longitude : this.model.get('location').longitude
-						};
-					}
-					else {
-						result = {
-							latitude : value,
-							longitude : ''
-						};
-					}
-					return result;
-				}
+				observe : 'latitude',
+				events : ['change']
 			},
 			'#longitude' : {
-				observe : 'location',
-				events : ['change'],
-				onGet : function(value) {
-					if (value && _.has(value, 'longitude')) {
-						return value.longitude;
-					}
-					else {
-						return '';
-					}
-				},
-				onSet : function(value) {
-					var result;
-					if (this.model.has('location')) {
-						result = {
-							latitude : this.model.get('location').latitude,
-							longitude : value,
-						};
-					}
-					else {
-						result = {
-							latitude : '',
-							longitude : value
-						};
-					}
-					return result;
-				}
+				observe : 'longitude',
+				events : ['change']
+			},
+			'#radius' : {
+				observe : 'radius',
+				events : ['change']
 			}
 		},
 
@@ -97,7 +53,7 @@ define([
 		getMyLocation : function(ev) {
 			var self = this;
 			var updateModel = function(position) {
-				self.model.set('location', {
+				self.model.set({
 					latitude : position.coords.latitude,
 					longitude : position.coords.longitude
 				});

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -249,9 +249,9 @@ define([
 
 		updateExtent : function(aoiModel) {
 			var bbox = aoiModel.getBoundingBox();
-			var southwest = L.latLng(bbox.south, bbox.west);
-			var northeast = L.latLng(bbox.north, bbox.east);
-			this.map.fitBounds(L.latLngBounds(southwest, northeast));
+			if (bbox) {
+				this.map.fitBounds(LUtils.getLatLngBounds(bbox));
+			}
 		},
 
 		setupDatasetListeners : function(model, datasetCollections) {
@@ -288,7 +288,8 @@ define([
 			};
 
 			var updateDataView = function(siteModel, siteLatLng) {
-				var projectLocation = L.latLng(self.model.attributes.location.latitude, self.model.attributes.location.longitude);
+				var bounds = LUtils.getLatLngBounds(self.model.get('aoi').getBoundingBox());
+				var	projectLocation = bounds.getCenter();
 
 				self.removeDataView();
 				self.selectedSite = {

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -96,8 +96,18 @@ define([
 			// Initialize draw control
 			this.drawnAOIFeature = L.featureGroup();
 			this.drawAOIControl = new L.Control.Draw({
+				draw : {
+					polyline : false,
+					polygon : false,
+					rectangle : {
+						repeatMode : false
+					},
+					circle : false,
+					marker : false
+				},
 				edit : {
-					featureGroup : this.drawnAOIFeature
+					featureGroup : this.drawnAOIFeature,
+					remove : false
 				}
 			});
 
@@ -261,6 +271,22 @@ define([
 					this.map.addLayer(this.drawnAOIFeature);
 					// TODO: Need to add code to add the AOI box if already defined
 					this.map.addControl(this.drawAOIControl);
+					this.map.on('draw:created', function(ev) {
+						this.model.get('aoi').set('aoiBox', LUtils.getBbox(ev.layer.getBounds()));
+					}, this);
+					this.map.on('draw:edited', function(ev) {
+						this.model.get('aoi').set('aoiBox', LUtils.getBbox(ev.layers.getLayers()[0].getBounds()));
+					}, this);
+				}
+				if (aoiModel.hasValidAOI()) {
+					var aoiLayers = this.drawnAOIFeature.getLayers();
+					var newLatLngBounds = LUtils.getLatLngBounds(aoiModel.get('aoiBox'));
+					if (aoiLayers.length === 0) {
+						this.drawnAOIFeature.addLayer(L.rectangle(newLatLngBounds, {}));
+					}
+					else {
+						aoiLayers[0].setBounds(newLatLngBounds);
+					}
 				}
 			}
 			else {

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -8,7 +8,6 @@ define([
 	'loglevel',
 	'Config',
 	'utils/jqueryUtils',
-	'utils/geoSpatialUtils',
 	'utils/LUtils',
 	'leafletCustomControls/legendControl',
 	'views/BaseView',
@@ -16,7 +15,7 @@ define([
 	'views/ACISDataView',
 	'views/NWISDataView',
 	'hbs!hb_templates/mapOps'
-], function(_, L, leafletDraw, leafletProviders, log, Config, $utils, geoSpatialUtils, LUtils, legendControl, BaseView,
+], function(_, L, leafletDraw, leafletProviders, log, Config, $utils, LUtils, legendControl, BaseView,
 		PrecipDataView, ACISDataView, NWISDataView, hbTemplate) {
 
 	var siteIcons = _.mapObject(Config.DATASET_ICON, function(value) {
@@ -287,6 +286,9 @@ define([
 					else {
 						aoiLayers[0].setBounds(newLatLngBounds);
 					}
+				}
+				else {
+					this.drawnAOIFeature.clearLayers();
 				}
 			}
 			else {

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -200,7 +200,7 @@ define([
 		updateWorkflowStep: function (model, newStep) {
 			var $map = this.$('#' + this.mapDivId);
 			switch (newStep) {
-				case Config.PROJ_LOC_STEP:
+				case Config.SPECIFY_AOI_STEP:
 					this.removeDataView();
 
 					if (this.map.hasLayer(this.circleMarker)) {

--- a/src/main/webapp/js/views/MapView.js
+++ b/src/main/webapp/js/views/MapView.js
@@ -134,6 +134,15 @@ define([
 				self.map.addLayer(layerGroup);
 			});
 
+			// Set up the map event handlers for the draw control to update the aoi model.
+			this.map.on('draw:created', function(ev) {
+				this.model.get('aoi').set('aoiBox', LUtils.getBbox(ev.layer.getBounds()));
+			}, this);
+			this.map.on('draw:edited', function(ev) {
+				this.model.get('aoi').set('aoiBox', LUtils.getBbox(ev.layers.getLayers()[0].getBounds()));
+			}, this);
+
+			// Set up model event listeners and update the map state to match the current state of the workflow model.
 			this.listenTo(this.model, 'change:step', this.updateWorkflowStep);
 			this.updateWorkflowStep(this.model, this.model.get('step'));
 
@@ -180,11 +189,9 @@ define([
 			var clickTimeout;
 			this.createMarkClickHandler = function(ev) {
 				var clickToAddMarkerToMap = function() {
-					self.model.set({
-						location : {
-							latitude : ev.latlng.lat,
-							longitude : ev.latlng.lng
-						}
+					self.model.get('aoi').set({
+						latitude : ev.latlng.lat,
+						longitude : ev.latlng.lng
 					});
 				};
 
@@ -269,14 +276,7 @@ define([
 				// Assuming that once the drawAOIFeature is on the map, it can only be changed via the map.
 				if (!mapHasAOIBox) {
 					this.map.addLayer(this.drawnAOIFeature);
-					// TODO: Need to add code to add the AOI box if already defined
 					this.map.addControl(this.drawAOIControl);
-					this.map.on('draw:created', function(ev) {
-						this.model.get('aoi').set('aoiBox', LUtils.getBbox(ev.layer.getBounds()));
-					}, this);
-					this.map.on('draw:edited', function(ev) {
-						this.model.get('aoi').set('aoiBox', LUtils.getBbox(ev.layers.getLayers()[0].getBounds()));
-					}, this);
 				}
 				if (aoiModel.hasValidAOI()) {
 					var aoiLayers = this.drawnAOIFeature.getLayers();

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -26,8 +26,8 @@ define([
 			aoiFragment = 'lat/' + latitude + '/lng/' + longitude + '/radius/' + radius;
 		}
 		else if (aoi.usingAOIBox()) {
-			//TODO ADD aoiFragment for AOI Box
-			aoiFragment = '';
+			var aoiBox = aoi.attributes.aoiBox;
+			aoiFragment = 'aoiBbox/' + aoiBox.south + ',' + aoiBox.west + ',' + aoiBox.north + ',' + aoiBox.east;
 		}
 
 		return aoiFragment + startDate + endDate + datasets;

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -135,7 +135,9 @@ define([
 						$processDataBtn.addClass('disabled');
 					}
 
-					this.router.navigate(getChooseDataUrl(model));
+					if (model.get('aoi').hasValidAOI()) {
+						this.router.navigate(getChooseDataUrl(model));
+					}
 					break;
 
 				case Config.PROCESS_DATA_STEP:
@@ -158,7 +160,9 @@ define([
 
 				case Config.CHOOSE_DATA_FILTERS_STEP:
 				case Config.CHOOSE_DATA_VARIABLES_STEP:
-					this.router.navigate(getChooseDataUrl(this.model));
+					if (this.model.get('aoi').hasValidAOI()) {
+						this.router.navigate(getChooseDataUrl(this.model));
+					}
 					break;
 			}
 		}

--- a/src/main/webapp/js/views/NavView.js
+++ b/src/main/webapp/js/views/NavView.js
@@ -14,7 +14,7 @@ define([
 		template : hb_template,
 
 		events : {
-			'click .nav-project-loc a' : 'showWarning',
+			'click .nav-specify-aoi a' : 'showWarning',
 			'click .nav-choose-data a' : 'goToChooseDataStep',
 			'click .nav-process-data a' : 'goToProcessDataStep',
 			'click .nav-warning-modal .ok-button' : 'goToProjectLocationStep'
@@ -30,12 +30,13 @@ define([
 			BaseView.prototype.initialize.apply(this, arguments);
 
 			this.navSelector = {};
-			this.navSelector[Config.PROJ_LOC_STEP] = '.nav-project-loc';
+			this.navSelector[Config.SPECIFY_AOI_STEP] = '.nav-specify-aoi';
 			this.navSelector[Config.CHOOSE_DATA_FILTERS_STEP] = '.nav-choose-data';
 			this.navSelector[Config.CHOOSE_DATA_VARIABLES_STEP] = '.nav-choose-data';
 			this.navSelector[Config.PROCESS_DATA_STEP] = '.nav-process-data';
 
 			this.listenTo(this.model, 'change', this.updateNavigation);
+			this.listenTo(this.model.get('aoi'), 'change', this.updateAOI);
 		},
 
 		render : function() {
@@ -50,15 +51,15 @@ define([
 		 */
 		showWarning : function(ev) {
 			ev.preventDefault();
-			if (this.model.get('step') !== Config.PROJ_LOC_STEP) {
+			if (this.model.get('step') !== Config.SPECIFY_AOI_STEP) {
 				this.$('.nav-warning-modal').modal('show');
 			}
 		},
 
 		goToProjectLocationStep : function(ev) {
 			ev.preventDefault();
-			if (this.model.get('step') !== Config.PROJ_LOC_STEP) {
-				this.model.set('step', Config.PROJ_LOC_STEP);
+			if (this.model.get('step') !== Config.SPECIFY_AOI_STEP) {
+				this.model.set('step', Config.SPECIFY_AOI_STEP);
 				this.$('.nav-warning-modal').modal('hide');
 			}
 		},
@@ -78,21 +79,30 @@ define([
 
 		_getChooseDataUrl : function(model) {
 			var state = model.attributes;
-			var latitude = (_.has(state, 'location') && _.has(state.location, 'latitude')) ? state.location.latitude : '';
-			var longitude = (_.has(state, 'location') && _.has(state.location, 'longitude')) ? state.location.longitude : '';
+			var aoi = model.attributes.aoi;
 
-			var location = 'lat/' + latitude + '/lng/' + longitude;
-			var radius = (state.radius) ? '/radius/' + state.radius : '';
 			var startDate = (state.startDate) ? '/startdate/' + state.startDate.format(Config.DATE_FORMAT_URL) : '';
 			var endDate = (state.endDate) ? '/enddate/' + state.endDate.format(Config.DATE_FORMAT_URL) : '';
 			var datasets = (state.datasets) ? '/dataset/' + state.datasets.join('/') : '';
-			return location + radius + startDate + endDate + datasets;
+
+			var aoiFragment = '';
+			if (aoi.usingProjectLocation()) {
+				var latitude = (aoi.attributes.latitude) ? aoi.attributes.latitude : '';
+				var longitude = (aoi.attributes.longitude) ? aoi.attributes.longitude : '';
+				var radius = (aoi.attributes.radius) ? aoi.attributes.radius : '';
+				aoiFragment = 'lat/' + latitude + '/lng/' + longitude + '/radius/' + radius;
+			}
+			else if (aoi.usingAOIBox()) {
+				//TODO ADD aoiFragment for AOI Box
+				aoiFragment = '';
+			}
+
+			return aoiFragment + startDate + endDate + datasets;
 		},
 
 		updateNavigation : function(model, isRendering) {
 			var stepHasChanged = isRendering ? true : model.hasChanged('step');
 			var newStep = model.get('step');
-			var location = model.get('location');
 
 			var $chooseDataBtn = this.$(this.navSelector[Config.CHOOSE_DATA_FILTERS_STEP]);
 			var $processDataBtn= this.$(this.navSelector[Config.PROCESS_DATA_STEP]);
@@ -104,9 +114,8 @@ define([
 				this.$(currentStepSelector).addClass('active');
 			}
 			switch(newStep) {
-				case Config.PROJ_LOC_STEP:
-					if ((location) && _.has(location, 'latitude') && (location.latitude) &&
-						_.has(location, 'longitude') && (location.longitude)) {
+				case Config.SPECIFY_AOI_STEP:
+					if (model.get('aoi').hasValidAOI()) {
 						$chooseDataBtn.removeClass('disabled');
 					}
 					else {
@@ -126,16 +135,24 @@ define([
 						$processDataBtn.addClass('disabled');
 					}
 
-					if (model.has('location') &&
-						_.has(model.attributes.location, 'latitude') && (model.attributes.location.latitude) &&
-						_.has(model.attributes.location, 'longitude') && (model.attributes.location.longitude)) {
-						this.router.navigate(this._getChooseDataUrl(model));
-					}
+					this.router.navigate(this._getChooseDataUrl(model));
 					break;
 
 				case Config.PROCESS_DATA_STEP:
-					//TODO: probably will need to add things here as we figure out this step.
 					break;
+			}
+		},
+
+		updateAOI : function() {
+			var $chooseDataBtn = this.$(this.navSelector[Config.CHOOSE_DATA_FILTERS_STEP]);
+
+			if (this.model.get('step') === Config.SPECIFY_AOI_STEP) {
+				if (this.model.get('aoi').hasValidAOI()) {
+						$chooseDataBtn.removeClass('disabled');
+				}
+				else {
+					$chooseDataBtn.addClass('disabled');
+				}
 			}
 		}
 

--- a/src/test/js/karma.conf.js
+++ b/src/test/js/karma.conf.js
@@ -21,6 +21,7 @@ module.exports = function (config) {
 			{pattern: 'src/main/webapp/bower_components/text/text.js', included: false},
 			{pattern: 'src/main/webapp/bower_components/requirejs-hbs/hbs.js', included: false},
 			{pattern: 'src/main/webapp/bower_components/leaflet/dist/leaflet.js', included: false},
+			{pattern: 'src/main/webapp/bower_components/leaflet-draw/dist/leaflet.draw.js', included: false},
 			{pattern: 'src/main/webapp/bower_components/leaflet-providers/leaflet-providers.js', included: false},
 			{pattern: 'src/main/webapp/bower_components/loglevel/dist/loglevel.js', included: false},
 			{pattern: 'src/main/webapp/bower_components/backbone.stickit/backbone.stickit.js', included : false},

--- a/src/test/js/models/AOIModelSpec.js
+++ b/src/test/js/models/AOIModelSpec.js
@@ -1,0 +1,168 @@
+/* jslint browser */
+/* global expect */
+
+define([
+	'utils/geoSpatialUtils',
+	'models/AOIModel'
+], function(geoSpatialUtils, AOIModel) {
+	"use strict";
+
+	fdescribe('models/AOIModel', function() {
+
+		var testModel;
+
+		beforeEach(function() {
+			testModel = new AOIModel();
+		});
+
+		describe('Tests for usingProjectLocation', function() {
+			it('Expects an empty model to return false', function() {
+				expect(testModel.usingProjectLocation()).toBe(false);
+			});
+
+			it('Expects that if the model contains latitude, longitude and radius properties, the function returns true', function() {
+				testModel.set({
+					latitude : '',
+					longitude : '',
+					radius : ''
+				});
+				expect(testModel.usingProjectLocation()).toBe(true);
+			});
+
+			it('Expects that if the model does not contain latitude, longtiude and radius properties, the function returns false', function() {
+				expect(testModel.usingProjectLocation()).toBe(false);
+				testModel.set('aoiBox', {});
+
+				expect(testModel.usingProjectLocation()).toBe(false);
+
+				testModel.unset('aoiBox');
+				testModel.set('latitude', '');
+
+				expect(testModel.usingProjectLocation()).toBe(false);
+
+				testModel.set('longitude', '');
+
+				expect(testModel.usingProjectLocation()).toBe(false);
+			});
+		});
+
+		describe('Tests for usingAOIBox', function() {
+			it('Expects an empty model to return false', function() {
+				expect(testModel.usingAOIBox()).toBe(false);
+			});
+
+			it('Expects that if the model contains aoiBox property, the function returns true', function() {
+				testModel.set('aoiBox', '');
+				expect(testModel.usingAOIBox()).toBe(true);
+			});
+
+			it('Expects that if the model does not contain aoiBox property, the function returns false', function() {
+				expect(testModel.usingAOIBox()).toBe(false);
+				testModel.set({
+					latitude : '',
+					longitude : '',
+					radius : ''
+				});
+
+				expect(testModel.usingAOIBox()).toBe(false);
+			});
+		});
+
+		describe('Tests for hasValidAOI', function() {
+			it('Expects that if the model is empty, the function returns false', function() {
+				expect(testModel.hasValidAOI()).toBe(false);
+			});
+
+			it('Expects that if the model contains a partially defined location/radius, the function returns false', function() {
+				testModel.set({
+					latitude : '',
+					longitude : '',
+					radius : ''
+				});
+
+				expect(testModel.hasValidAOI()).toBe(false);
+
+				testModel.set('radius', 2);
+				expect(testModel.hasValidAOI()).toBe(false);
+			});
+
+			it('Expects that if the model contains a valid location/radius, the function returns true', function() {
+				testModel.set({
+					latitude : 43.0,
+					longitude : -100.0,
+					radius : 2
+				});
+
+				expect(testModel.hasValidAOI()).toBe(true);
+			});
+
+			it('Expects that if the model contains a partially defined aoiBox property, the function returns false', function() {
+				testModel.set('aoiBox', '');
+
+				expect(testModel.hasValidAOI()).toBe(false);
+			});
+
+			it('Expects that if the model contains a fully defined aoiBox property, the function returns true', function() {
+				testModel.set('aoiBox', {
+					south : 43.0,
+					west : -102.0,
+					north : 44.0,
+					east : -101.0
+				});
+			});
+		});
+
+		describe('Tests for getBoundingBox', function() {
+			it('Expects an empty model to return undefined', function() {
+				expect(testModel.getBoundingBox()).toBeUndefined();
+			});
+
+			it('Expects that a partially defined location/radius returns undefined', function() {
+				testModel.set({
+					latitude : '',
+					longitude : '',
+					radius : ''
+				});
+
+				expect(testModel.getBoundingBox()).toBeUndefined();
+
+				testModel.set('latitude', 43.0);
+
+				expect(testModel.getBoundingBox()).toBeUndefined();
+
+				testModel.set('radius', 2);
+
+				expect(testModel.getBoundingBox()).toBeUndefined();
+			});
+
+			it('Expects that a fully defined location/radius returns the expected bounding box', function() {
+				var testValue = {
+					latitude : 43.0,
+					longitude : -100.0,
+					radius : 2
+				};
+				testModel.set(testValue);
+
+				expect(testModel.getBoundingBox()).toEqual(geoSpatialUtils.getBoundingBox(testValue.latitude, testValue.longitude, testValue.radius));
+			});
+
+			it('Expects that a paritally defined aoiBox returns undefined', function() {
+				testModel.set('aoiBox', {});
+
+				expect(testModel.getBoundingBox()).toBeUndefined();
+			});
+
+			it('Expects that a fully defined aoiBox returns the expected bounding box', function() {
+				var testValue = {
+					south : 42.0,
+					west : -101.0,
+					north : 43.0,
+					east : -100.0
+				};
+				testModel.set('aoiBox', testValue);
+
+				expect(testModel.getBoundingBox()).toEqual(testValue);
+			});
+		});
+	});
+});

--- a/src/test/js/models/AOIModelSpec.js
+++ b/src/test/js/models/AOIModelSpec.js
@@ -7,7 +7,7 @@ define([
 ], function(geoSpatialUtils, AOIModel) {
 	"use strict";
 
-	fdescribe('models/AOIModel', function() {
+	describe('models/AOIModel', function() {
 
 		var testModel;
 

--- a/src/test/js/models/WorkflowStateModelSpec.js
+++ b/src/test/js/models/WorkflowStateModelSpec.js
@@ -250,9 +250,7 @@ define([
 				});
 				testModel.set('step', Config.SPECIFY_AOI_STEP);
 
-				expect(aoiModel.get('latitude')).toEqual('');
-				expect(aoiModel.get('longitude')).toEqual('');
-				expect(aoiModel.get('radius')).not.toEqual('');
+				expect(aoiModel.attributes).toEqual({});
 				expect(testModel.has('datasets')).toBe(false);
 				expect(testModel.has('startDate')).toBe(false);
 				expect(testModel.has('endDate')).toBe(false);
@@ -270,7 +268,7 @@ define([
 
 			it('Expects that if the step changes to CHOOSE_DATA_FILTERS_STEP and the previous step was SPECIFY_AOI_STEP that the chosen datasets are set', function() {
 				testModel.set('step', Config.SPECIFY_AOI_STEP);
-				testModel.get('aoi').set({latitude : '43.0', longitude : '-100.0'});
+				testModel.get('aoi').set({latitude : '43.0', longitude : '-100.0', radius : 2});
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 
 				expect(testModel.get('datasets')).toEqual(['NWIS']);
@@ -278,7 +276,7 @@ define([
 
 			it('Expects that if the step changes to CHOOSE_DATA_FILTERS_STEP and the previous step was SPECIFY_AOI_STEP, the chosen datasets are fetched', function() {
 				testModel.set('step', Config.SPECIFY_AOI_STEP);
-				testModel.get('aoi').set({latitude : '43.0', longitude : '-100.0'});
+				testModel.get('aoi').set({latitude : '43.0', longitude : '-100.0', radius : 2});
 				fetchPrecipSpy.calls.reset();
 				fetchSiteSpy.calls.reset();
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);

--- a/src/test/js/test-main.js
+++ b/src/test/js/test-main.js
@@ -40,6 +40,7 @@ require.config({
 		'hbs' : '/base/src/main/webapp/bower_components/requirejs-hbs/hbs',
 		'leaflet' : '/base/src/main/webapp/bower_components/leaflet/dist/leaflet',
 		'leaflet-providers' : '/base/src/main/webapp/bower_components/leaflet-providers/leaflet-providers',
+		'leaflet-draw' : '/base/src/main/webapp/bower_components/leaflet-draw/dist/leaflet.draw',
 		'loglevel' : '/base/src/main/webapp/bower_components/loglevel/dist/loglevel',
 		'backbone.stickit' : '/base/src/main/webapp/bower_components/backbone.stickit/backbone.stickit',
 		'moment' : '/base/src/main/webapp/bower_components/moment/moment',
@@ -50,6 +51,7 @@ require.config({
 		'leaflet' : {
 			exports: 'L'
 		},
+		'leaflet-draw' : ['leaflet'],
 		'leaflet-providers' : ['leaflet'],
 		'backbone': {
 			deps: ['jquery', 'underscore'],

--- a/src/test/js/views/AOIBoxViewSpec.js
+++ b/src/test/js/views/AOIBoxViewSpec.js
@@ -1,0 +1,69 @@
+/* jslint browser: true */
+/* global expect, spyOn */
+
+define([
+	'jquery',
+	'models/AOIModel',
+	'views/AOIBoxView'
+], function($, AOIModel, AOIBoxView) {
+	"use strict";
+
+	describe('Tests for views/AOIBoxView', function() {
+		var testView;
+		var $testDiv;
+		var testModel;
+
+		beforeEach(function() {
+			$('body').append('<div id="test-div"></div>');
+			$testDiv = $('#test-div');
+
+			testModel = new AOIModel({
+				aoiBox : {
+					south : 43.0,
+					west : -101.0,
+					north : 44.0,
+					east : -100.0
+				}
+			});
+
+			testView = new AOIBoxView({
+				model : testModel,
+				el : $testDiv,
+				opened : true
+			});
+
+			spyOn(testView, 'template').and.callThrough();
+		});
+
+		afterEach(function() {
+			if (testView) {
+				testView.remove();
+			}
+
+			$testDiv.remove();
+		});
+
+		it('Expects that the model attributes are passed to the context when rendering the view', function() {
+			testView.render();
+			expect(testView.template).toHaveBeenCalledWith(testModel.attributes.aoiBox);
+		});
+
+		it('Expects that the template is re rendered whenevr the model is updated', function() {
+			testView.render();
+			testView.template.calls.reset();
+			testModel.set('aoiBox', {
+				south : 43.0,
+				west : -102.0,
+				north : 44.0,
+				east : -100.0
+			});
+
+			expect(testView.template).toHaveBeenCalledWith(testModel.attributes.aoiBox);
+
+			testView.template.calls.reset();
+			testModel.set('aoiBox', {});
+
+			expect(testView.template).toHaveBeenCalledWith({});
+		});
+	});
+});

--- a/src/test/js/views/ChooseViewSpec.js
+++ b/src/test/js/views/ChooseViewSpec.js
@@ -25,7 +25,7 @@ define([
 			$testDiv = $('#test-div');
 
 			testModel = new WorkflowStateModel();
-			testModel.set('step', Config.PROJ_LOC_STEP);
+			testModel.set('step', Config.SPECIFY_AOI_STEP);
 
 			testView = new ChooseView({
 				el : $testDiv,
@@ -51,13 +51,11 @@ define([
 
 			it('Expects the inputs to reflect the values in the model', function() {
 				testModel.set({
-					radius : '2',
 					startDate : moment('2001-01-01', DATE_FORMAT),
 					endDate : moment('2010-01-01', DATE_FORMAT),
 					datasets : [Config.NWIS_DATASET]
 				});
 				testView.render();
-				expect($testDiv.find('#radius').val()).toEqual('2');
 				expect($testDiv.find('#start-date').val()).toEqual('2001-01-01');
 				expect($testDiv.find('#end-date').val()).toEqual('2010-01-01');
 				expect($testDiv.find('#datasets-select').val()).toEqual([Config.NWIS_DATASET]);
@@ -68,16 +66,10 @@ define([
 			var $rad, $datasets, $startDate, $endDate;
 			beforeEach(function() {
 				testView.render();
-				$rad = $testDiv.find('#radius');
 				$datasets = $testDiv.find('#datasets-select');
 				$startDate = $testDiv.find('#start-date');
 				$endDate = $testDiv.find('#end-date');
 
-			});
-
-			it('Expects that changing the radius updates the model\'s radius property', function() {
-				$rad.val('5').trigger('change');
-				expect(testModel.get('radius')).toEqual('5');
 			});
 
 			// Have to call the select2 event handlers directly
@@ -109,15 +101,9 @@ define([
 			var $rad, $datasets, $startDate, $endDate;
 			beforeEach(function() {
 				testView.render();
-				$rad = $testDiv.find('#radius');
 				$datasets = $testDiv.find('#datasets-select');
 				$startDate = $testDiv.find('#start-date-div');
 				$endDate = $testDiv.find('#end-date-div');
-			});
-
-			it('Expects that if the model\'s radius property is updated the radius field is updated', function() {
-				testModel.set('radius', '5');
-				expect($rad.val()).toEqual('5');
 			});
 
 			it('Expects that if the model\'s datasets property is updated the datasets field is updated', function() {

--- a/src/test/js/views/DataDiscoveryViewSpec.js
+++ b/src/test/js/views/DataDiscoveryViewSpec.js
@@ -465,6 +465,7 @@ define([
 
 			it('Expects that if the step changes from SPECIFY_AOI_STEP to CHOOSE_DATA_FILTERS_STEP, the choose view and summary views are created and rendered', function() {
 				testModel.set('step', Config.SPECIFY_AOI_STEP);
+				$testDiv.find('.workflow-start-container select').val('location').trigger('change');
 				setElChooseViewSpy.calls.reset();
 				renderChooseViewSpy.calls.reset();
 				setElSummaryViewSpy.calls.reset();

--- a/src/test/js/views/DataDiscoveryViewSpec.js
+++ b/src/test/js/views/DataDiscoveryViewSpec.js
@@ -148,7 +148,7 @@ define([
 
 				testModel = new WorkflowStateModel();
 				spyOn(testModel, 'updateDatasetCollections');
-				testModel.set('step', Config.PROJ_LOC_STEP);
+				testModel.set('step', Config.SPECIFY_AOI_STEP);
 
 				done();
 			});
@@ -225,8 +225,8 @@ define([
 				expect(renderNavViewSpy.calls.count()).toBe(3);
 			});
 
-			it('Expects that if the workflow step is PROJ_LOC_STEP, the location and map views are created and rendered but not the choose data view', function() {
-				testModel.set('step', Config.PROJ_LOC_STEP);
+			it('Expects that if the workflow step is SPECIFY_AOI_STEP, the location and map views are created and rendered but not the choose data view', function() {
+				testModel.set('step', Config.SPECIFY_AOI_STEP);
 				testView.render();
 
 				expect(setElMapViewSpy).toHaveBeenCalled();
@@ -278,7 +278,7 @@ define([
 			});
 
 			it('Expects that the location and map subviews are removed if they have been created', function() {
-				testModel.set('step', Config.PROJ_LOC_STEP);
+				testModel.set('step', Config.SPECIFY_AOI_STEP);
 				testView.render();
 				testView.remove();
 
@@ -363,19 +363,19 @@ define([
 				expect(showSuccessAlertSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to PROJ_LOC_STEP, the choose view and summary view are removed and the location view is expanded', function() {
+			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to SPECIFY_AOI_STEP, the choose view and summary view are removed and the location view is expanded', function() {
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				removeChooseViewSpy.calls.reset();
 				removeSummaryViewSpy.calls.reset();
-				testModel.set('step', Config.PROJ_LOC_STEP);
+				testModel.set('step', Config.SPECIFY_AOI_STEP);
 
 				expect(removeChooseViewSpy).toHaveBeenCalled();
 				expect(removeSummaryViewSpy).toHaveBeenCalled();
 				expect(expandLocationViewSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that if the step changes from PROJ_LOC_STEP to CHOOSE_DATA_FILTERS_STEP, the choose view and summary views are created and rendered', function() {
-				testModel.set('step', Config.PROJ_LOC_STEP);
+			it('Expects that if the step changes from SPECIFY_AOI_STEP to CHOOSE_DATA_FILTERS_STEP, the choose view and summary views are created and rendered', function() {
+				testModel.set('step', Config.SPECIFY_AOI_STEP);
 				setElChooseViewSpy.calls.reset();
 				renderChooseViewSpy.calls.reset();
 				setElSummaryViewSpy.calls.reset();
@@ -441,7 +441,7 @@ define([
 				expect(removeProcessDataViewSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that if the step is PROCESS_DATA_STEP and changes to PROJ_LOC_STEP, the process data and summary views are removed, and the location view is created', function() {
+			it('Expects that if the step is PROCESS_DATA_STEP and changes to SPECIFY_AOI_STEP, the process data and summary views are removed, and the location view is created', function() {
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
 				testModel.set({
@@ -452,7 +452,7 @@ define([
 				removeProcessDataViewSpy.calls.reset();
 				removeSummaryViewSpy.calls.reset();
 				renderLocationViewSpy.calls.reset();
-				testModel.set('step', Config.PROJ_LOC_STEP);
+				testModel.set('step', Config.SPECIFY_AOI_STEP);
 
 				expect(removeProcessDataViewSpy).toHaveBeenCalled();
 				expect(removeSummaryViewSpy).toHaveBeenCalled();
@@ -461,7 +461,7 @@ define([
 
 			it('Expects that if the step changes, the alert view is closed', function() {
 				closeAlertSpy.calls.reset();
-				testModel.set('step', Config.PROJ_LOC_STEP);
+				testModel.set('step', Config.SPECIFY_AOI_STEP);
 
 				expect(closeAlertSpy).toHaveBeenCalled();
 			});

--- a/src/test/js/views/DataDiscoveryViewSpec.js
+++ b/src/test/js/views/DataDiscoveryViewSpec.js
@@ -22,6 +22,7 @@ define([
 		var setElNavViewSpy, renderNavViewSpy, removeNavViewSpy;
 		var setElMapViewSpy, renderMapViewSpy, removeMapViewSpy;
 		var setElLocationViewSpy, renderLocationViewSpy, removeLocationViewSpy, collapseLocationViewSpy, expandLocationViewSpy;
+		var setElAOIBoxViewSpy, renderAOIBoxViewSpy, removeAOIBoxViewSpy, collapseAOIBoxViewSpy, expandAOIBoxViewSpy;
 		var setElChooseViewSpy, renderChooseViewSpy, removeChooseViewSpy, collapseChooseViewSpy, expandChooseViewSpy;
 		var setElSummaryViewSpy, renderSummaryViewSpy, removeSummaryViewSpy, collapseSummaryViewSpy, expandSummaryViewSpy;
 		var setElProcessDataViewSpy, renderProcessDataViewSpy, removeProcessDataViewSpy;
@@ -51,6 +52,12 @@ define([
 			removeLocationViewSpy = jasmine.createSpy('removeLocationViewSpy');
 			collapseLocationViewSpy = jasmine.createSpy('collapseLocationViewSpy');
 			expandLocationViewSpy = jasmine.createSpy('expandLocationViewSpy');
+
+			setElAOIBoxViewSpy = jasmine.createSpy('setElAOIBoxViewSpy');
+			renderAOIBoxViewSpy = jasmine.createSpy('renderAOIBoxViewSpy');
+			removeAOIBoxViewSpy = jasmine.createSpy('removeAOIBoxViewSpy');
+			collapseAOIBoxViewSpy = jasmine.createSpy('collapseAOIBoxViewSpy');
+			expandAOIBoxViewSpy = jasmine.createSpy('expandAOIBoxViewSpy');
 
 			setElChooseViewSpy = jasmine.createSpy('setElChooseViewSpy');
 			renderChooseViewSpy = jasmine.createSpy('renderChooseViewSpy');
@@ -104,6 +111,16 @@ define([
 				remove : removeLocationViewSpy,
 				expand : expandLocationViewSpy,
 				collapse : collapseLocationViewSpy
+			}));
+
+			injector.mock('views/AOIBoxView', BaseView.extend({
+				setElement : setElAOIBoxViewSpy.and.returnValue({
+					render : renderAOIBoxViewSpy
+				}),
+				render : renderAOIBoxViewSpy,
+				remove : removeAOIBoxViewSpy,
+				expand : expandAOIBoxViewSpy,
+				collapse : collapseAOIBoxViewSpy
 			}));
 
 			injector.mock('views/ChooseView', BaseView.extend({
@@ -180,6 +197,7 @@ define([
 			expect(setElNavViewSpy.calls.count()).toBe(1);
 			expect(setElMapViewSpy.calls.count()).toBe(0);
 			expect(setElLocationViewSpy.calls.count()).toBe(0);
+			expect(setElAOIBoxViewSpy.calls.count()).toBe(0);
 			expect(setElChooseViewSpy.calls.count()).toBe(0);
 			expect(setElSummaryViewSpy.calls.count()).toBe(0);
 			expect(setElAlertViewSpy.calls.count()).toBe(1);
@@ -225,27 +243,57 @@ define([
 				expect(renderNavViewSpy.calls.count()).toBe(3);
 			});
 
-			it('Expects that if the workflow step is SPECIFY_AOI_STEP, the location and map views are created and rendered but not the choose data view', function() {
+			it('Expects that if the workflow step is SPECIFY_AOI_STEP and the aoi model contains no properties no child views other than navs are created and the workflow start container is visible', function() {
 				testModel.set('step', Config.SPECIFY_AOI_STEP);
 				testView.render();
 
-				expect(setElMapViewSpy).toHaveBeenCalled();
-				expect(renderMapViewSpy).toHaveBeenCalled();
-				expect(setElLocationViewSpy).toHaveBeenCalled();
-				expect(renderLocationViewSpy).toHaveBeenCalled();
+				expect(setElMapViewSpy).not.toHaveBeenCalled();
+				expect(renderMapViewSpy).not.toHaveBeenCalled();
+				expect(setElLocationViewSpy).not.toHaveBeenCalled();
+				expect(renderLocationViewSpy).not.toHaveBeenCalled();
 				expect(setElChooseViewSpy).not.toHaveBeenCalled();
 				expect(setElSummaryViewSpy).not.toHaveBeenCalled();
 				expect(setElProcessDataViewSpy).not.toHaveBeenCalled();
+				expect($testDiv.find('.workflow-start-container').is(':visible')).toBe(true);
 			});
 
-			it('Expects that if the workflow step is CHOOSE_DATA_FILTERS_STEP, the location, map, variable summary and choose data views are created and rendered', function() {
+			it('Expects that if the workflow step is CHOOSE_DATA_FILTERS_STEP and the aoi model contains a location, the location, map, variable summary and choose data views are created and rendered', function() {
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				testModel.get('aoi').set({
+					latitude : 42.0,
+					longitude : 43.0,
+					radius : 2
+				});
 				testView.render();
 
 				expect(setElMapViewSpy).toHaveBeenCalled();
 				expect(renderMapViewSpy).toHaveBeenCalled();
 				expect(setElLocationViewSpy).toHaveBeenCalled();
 				expect(renderLocationViewSpy).toHaveBeenCalled();
+				expect(setElAOIBoxViewSpy).not.toHaveBeenCalled();
+				expect(renderAOIBoxViewSpy).not.toHaveBeenCalled();
+				expect(setElChooseViewSpy).toHaveBeenCalled();
+				expect(renderChooseViewSpy).toHaveBeenCalled();
+				expect(setElSummaryViewSpy).toHaveBeenCalled();
+				expect(renderSummaryViewSpy).toHaveBeenCalled();
+			});
+
+			it('Expects that if the workflow step is CHOOSE_DATA_FILTERS_STEP and the aoi model contains an AOI box, the location, map, variable summary and choose data views are created and rendered', function() {
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				testModel.get('aoi').set('aoiBox', {
+					south : 42.0,
+					west : -101.0,
+					north : 43.0,
+					east : -100.0
+				});
+				testView.render();
+
+				expect(setElMapViewSpy).toHaveBeenCalled();
+				expect(renderMapViewSpy).toHaveBeenCalled();
+				expect(setElLocationViewSpy).not.toHaveBeenCalled();
+				expect(renderLocationViewSpy).not.toHaveBeenCalled();
+				expect(setElAOIBoxViewSpy).toHaveBeenCalled();
+				expect(renderAOIBoxViewSpy).toHaveBeenCalled();
 				expect(setElChooseViewSpy).toHaveBeenCalled();
 				expect(renderChooseViewSpy).toHaveBeenCalled();
 				expect(setElSummaryViewSpy).toHaveBeenCalled();
@@ -271,6 +319,7 @@ define([
 				expect(removeNavViewSpy).toHaveBeenCalled();
 				expect(removeAlertViewSpy).toHaveBeenCalled();
 				expect(removeLocationViewSpy).not.toHaveBeenCalled();
+				expect(removeAOIBoxViewSpy).not.toHaveBeenCalled();
 				expect(removeChooseViewSpy).not.toHaveBeenCalled();
 				expect(removeSummaryViewSpy).not.toHaveBeenCalled();
 				expect(removeProcessDataViewSpy).not.toHaveBeenCalled();
@@ -280,6 +329,7 @@ define([
 			it('Expects that the location and map subviews are removed if they have been created', function() {
 				testModel.set('step', Config.SPECIFY_AOI_STEP);
 				testView.render();
+				$testDiv.find('.workflow-start-container select').val('location').trigger('change');
 				testView.remove();
 
 				expect(removeLocationViewSpy).toHaveBeenCalled();
@@ -287,12 +337,45 @@ define([
 				expect(removeMapViewSpy).toHaveBeenCalled();
 			});
 
+			it('Expects that the aoiBox and map subviews are removed if they have been created', function() {
+				testModel.set('step', Config.SPECIFY_AOI_STEP);
+				testView.render();
+				$testDiv.find('.workflow-start-container select').val('aoiBox').trigger('change');
+				testView.remove();
+
+				expect(removeAOIBoxViewSpy).toHaveBeenCalled();
+				expect(removeChooseViewSpy).not.toHaveBeenCalled();
+				expect(removeMapViewSpy).toHaveBeenCalled();
+			});
+
 			it('Expects that the location,map, variable summary, and choose data subviews are removed if they have been created', function() {
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				testModel.get('aoi').set({
+					latitude : 42.0,
+					longitude : -100.0,
+					radius : 2
+				});
 				testView.render();
 				testView.remove();
 
 				expect(removeLocationViewSpy).toHaveBeenCalled();
+				expect(removeChooseViewSpy).toHaveBeenCalled();
+				expect(removeSummaryViewSpy).toHaveBeenCalled();
+				expect(removeMapViewSpy).toHaveBeenCalled();
+			});
+
+			it('Expects that the AOI box, map, variable summary, and choose data subviews are removed if they have been created', function() {
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				testModel.get('aoi').set('aoiBox', {
+					south : 42.0,
+					west : -101.0,
+					north : 41.0,
+					east : -100.0
+				});
+				testView.render();
+				testView.remove();
+
+				expect(removeAOIBoxViewSpy).toHaveBeenCalled();
 				expect(removeChooseViewSpy).toHaveBeenCalled();
 				expect(removeSummaryViewSpy).toHaveBeenCalled();
 				expect(removeMapViewSpy).toHaveBeenCalled();
@@ -319,6 +402,11 @@ define([
 					model : testModel
 				});
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				testModel.get('aoi').set({
+					latitude : 42.0,
+					longitude : -100.0,
+					radius : 2
+				});
 				testView.render();
 			});
 			it('Expects the loading indicator to be shown when the dataset:updateStart event is triggered on the model', function() {
@@ -363,15 +451,16 @@ define([
 				expect(showSuccessAlertSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to SPECIFY_AOI_STEP, the choose view and summary view are removed and the location view is expanded', function() {
+			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to SPECIFY_AOI_STEP, the location view, choose view and summary view are removed', function() {
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				removeChooseViewSpy.calls.reset();
 				removeSummaryViewSpy.calls.reset();
+				removeLocationViewSpy.calls.reset();
 				testModel.set('step', Config.SPECIFY_AOI_STEP);
 
 				expect(removeChooseViewSpy).toHaveBeenCalled();
 				expect(removeSummaryViewSpy).toHaveBeenCalled();
-				expect(expandLocationViewSpy).toHaveBeenCalled();
+				expect(removeLocationViewSpy).toHaveBeenCalled();
 			});
 
 			it('Expects that if the step changes from SPECIFY_AOI_STEP to CHOOSE_DATA_FILTERS_STEP, the choose view and summary views are created and rendered', function() {
@@ -389,7 +478,6 @@ define([
 			});
 
 			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to CHOOSE_DATA_VARIABLE_STEP, the location and choose views are collapsed', function() {
-				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				collapseLocationViewSpy.calls.reset();
 				collapseChooseViewSpy.calls.reset();
 				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
@@ -441,7 +529,7 @@ define([
 				expect(removeProcessDataViewSpy).toHaveBeenCalled();
 			});
 
-			it('Expects that if the step is PROCESS_DATA_STEP and changes to SPECIFY_AOI_STEP, the process data and summary views are removed, and the location view is created', function() {
+			it('Expects that if the step is PROCESS_DATA_STEP and changes to SPECIFY_AOI_STEP, the process data and summary views are removed', function() {
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
 				testModel.set({
@@ -451,12 +539,10 @@ define([
 				testModel.set('step', Config.PROCESS_DATA_STEP);
 				removeProcessDataViewSpy.calls.reset();
 				removeSummaryViewSpy.calls.reset();
-				renderLocationViewSpy.calls.reset();
 				testModel.set('step', Config.SPECIFY_AOI_STEP);
 
 				expect(removeProcessDataViewSpy).toHaveBeenCalled();
 				expect(removeSummaryViewSpy).toHaveBeenCalled();
-				expect(renderLocationViewSpy).toHaveBeenCalled();
 			});
 
 			it('Expects that if the step changes, the alert view is closed', function() {
@@ -471,6 +557,85 @@ define([
 				testModel.set('datasets', null);
 
 				expect(closeAlertSpy).toHaveBeenCalled();
+			});
+		});
+		describe('Step changes when AOI Box is used', function() {
+			beforeEach(function() {
+				testView = new DataDiscoveryView({
+						el : $testDiv,
+						model : testModel
+					});
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				testModel.get('aoi').set('aoiBox', {
+					south : 42.0,
+					west : -101.0,
+					north : 43.0,
+					east : -100.0
+				});
+				testView.render();
+			});
+
+			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to SPECIFY_AOI_STEP, the aoiBox view, choose view and summary view are removed', function() {
+				removeAOIBoxViewSpy.calls.reset();
+				removeChooseViewSpy.calls.reset();
+				removeSummaryViewSpy.calls.reset();
+				testModel.set('step', Config.SPECIFY_AOI_STEP);
+
+				expect(removeChooseViewSpy).toHaveBeenCalled();
+				expect(removeSummaryViewSpy).toHaveBeenCalled();
+				expect(removeAOIBoxViewSpy).toHaveBeenCalled();
+			});
+
+			it('Expects that if the step changes from CHOOSE_DATA_FILTERS_STEP to CHOOSE_DATA_VARIABLE_STEP, the aoiBox and choose views are collapsed', function() {
+				collapseAOIBoxViewSpy.calls.reset();
+				collapseChooseViewSpy.calls.reset();
+				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
+
+				expect(collapseAOIBoxViewSpy).toHaveBeenCalled();
+				expect(collapseChooseViewSpy).toHaveBeenCalled();
+			});
+
+			it('Expects that if the step changes from CHOOSE_DATA_VARIABLES_STEP to PROCESS_DATA_STEP, the process data view is created and rendered, the location,choose, and map views are removed and variable summary is collapsed', function() {
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
+				removeAOIBoxViewSpy.calls.reset();
+				removeChooseViewSpy.calls.reset();
+				removeMapViewSpy.calls.reset();
+				collapseSummaryViewSpy.calls.reset();
+				renderProcessDataViewSpy.calls.reset();
+				testModel.set({
+					startDate : moment('2005-04-01', Config.DATE_FORMAT),
+					endDate : moment('2009-03-11', Config.DATE_FORMAT)
+				});
+				testModel.set('step', Config.PROCESS_DATA_STEP);
+
+				expect(removeAOIBoxViewSpy).toHaveBeenCalled();
+				expect(removeChooseViewSpy).toHaveBeenCalled();
+				expect(removeMapViewSpy).toHaveBeenCalled();
+				expect(collapseSummaryViewSpy).toHaveBeenCalled();
+				expect(renderProcessDataViewSpy).toHaveBeenCalled();
+			});
+
+			it('Expects that if the step is PROCESS_DATA_STEP and goes back to CHOOSE_DATA_FILTERS_STEP, the process data view is removed, the aoiBox, choose, and map view are created and the variable summary is shown', function() {
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
+				testModel.set({
+					startDate : moment('2005-04-01', Config.DATE_FORMAT),
+					endDate : moment('2009-03-11', Config.DATE_FORMAT)
+				});
+				testModel.set('step', Config.PROCESS_DATA_STEP);
+				renderAOIBoxViewSpy.calls.reset();
+				renderChooseViewSpy.calls.reset();
+				renderMapViewSpy.calls.reset();
+				expandSummaryViewSpy.calls.reset();
+				removeProcessDataViewSpy.calls.reset();
+				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
+
+				expect(renderAOIBoxViewSpy).toHaveBeenCalled();
+				expect(renderChooseViewSpy).toHaveBeenCalled();
+				expect(renderMapViewSpy).toHaveBeenCalled();
+				expect(expandSummaryViewSpy).toHaveBeenCalled();
+				expect(removeProcessDataViewSpy).toHaveBeenCalled();
 			});
 		});
 	});

--- a/src/test/js/views/LocationViewSpec.js
+++ b/src/test/js/views/LocationViewSpec.js
@@ -3,9 +3,9 @@
 
 define([
 	'jquery',
-	'models/WorkflowStateModel',
+	'models/AOIModel',
 	'views/LocationView'
-], function($, WorkflowStateModel, LocationView) {
+], function($, AOIModel, LocationView) {
 	"use strict";
 
 	describe('views/LocationView', function() {
@@ -19,10 +19,12 @@ define([
 			$('body').append('<div id="test-div"></div>');
 			$testDiv = $('#test-div');
 
-			testModel = new WorkflowStateModel({}, {
-				createDatasetModels : true
+			testModel = new AOIModel({
+				latitude : '',
+				longitude : '',
+				radius : ''
 			});
-			testModel.set('step', testModel.PROJ_LOC_STEP);
+			testModel.set('step', testModel.SPECIFY_AOI_STEP);
 
 			testView = new LocationView({
 				el : $testDiv,
@@ -51,54 +53,43 @@ define([
 		});
 
 		describe('DOM event handler tests', function() {
-			var $lat, $lng, $useLocBtn;
+			var $lat, $lng, $radius, $useLocBtn;
 			beforeEach(function() {
 				testView.render();
 				$lat = $testDiv.find('#latitude');
 				$lng = $testDiv.find('#longitude');
+				$radius = $testDiv.find('#radius');
 				$useLocBtn = $testDiv.find('.use-location-btn');
 
 				spyOn(navigator.geolocation, 'getCurrentPosition');
 			});
 
-			it('Expects that changing the latitude updates the model\'s location property', function() {
+			it('Expects that changing the latitude updates the model\'s latitude property', function() {
 				$lat.val('43.0').trigger('change');
-				expect(testModel.get('location')).toEqual({
-					latitude : '43.0',
-					longitude : ''
-				});
+
+				expect(testModel.get('latitude')).toEqual('43.0')
 
 				$lat.val('42.0').trigger('change');
-				expect(testModel.get('location')).toEqual({
-					latitude : '42.0',
-					longitude : ''
-				});
+
+				expect(testModel.get('latitude')).toEqual('42.0');
 
 				$lat.val('').trigger('change');
-				expect(testModel.get('location')).toEqual({
-					latitude : '',
-					longitude : ''
-				});
+
+				expect(testModel.get('latitude')).toEqual('');
 			});
 
-			it('Expects that changing the longitude updates the model\'s location property', function() {
+			it('Expects that changing the longitude updates the model\'s longitude property', function() {
 				$lng.val('-100.0').trigger('change');
-				expect(testModel.get('location')).toEqual({
-					latitude : '',
-					longitude : '-100.0'
-				});
+
+				expect(testModel.get('longitude')).toEqual('-100.0');
 
 				$lng.val('-101.0').trigger('change');
-				expect(testModel.get('location')).toEqual({
-					latitude : '',
-					longitude : '-101.0'
-				});
+
+				expect(testModel.get('longitude')).toEqual('-101.0');
 
 				$lng.val('').trigger('change');
-				expect(testModel.get('location')).toEqual({
-					latitude : '',
-					longitude : ''
-				});
+
+				expect(testModel.get('longitude')).toEqual('');
 			});
 
 			it('Expects that geolocation is called if the use my location button is clicked', function() {
@@ -116,42 +107,65 @@ define([
 					}
 				});
 
-				expect(testModel.get('location')).toEqual({
-					latitude : '43.0',
-					longitude : '-100.0'
-				});
+				expect(testModel.get('latitude')).toEqual('43.0');
+				expect(testModel.get('longitude')).toEqual('-100.0');
+			});
+
+			it('Expects that changing the radius updates the model\'s radius property', function() {
+				$radius.val('5').trigger('change');
+
+				expect(testModel.get('radius')).toEqual('5');
+
+				$radius.val('4').trigger('change');
+
+				expect(testModel.get('radius')).toEqual('4');
+
+				$radius.val('').trigger('change');
+
+				expect(testModel.get('radius')).toEqual('');
 			});
 		});
 
 		describe('Model event handlers', function() {
-			var $lat, $lng;
+			var $lat, $lng, $radius;
 			beforeEach(function() {
 				testView.render();
 				$lat = $testDiv.find('#latitude');
 				$lng = $testDiv.find('#longitude');
+				$radius = $testDiv.find('#radius');
 			});
 
-			it('Expects that if the model\'s location property the latitude and longitude fields are updated', function() {
-				testModel.set('location', {
-					latitude : '43.0',
-					longitude : '-100.0'
-				});
+			it('Expects that when the model\'s latitude property is updated, the DOM is update', function() {
+				testModel.set('latitude', '43.0');
 				expect($lat.val()).toEqual('43.0');
+
+				testModel.set('latitude', '44.0');
+				expect($lat.val()).toEqual('44.0');
+
+				testModel.set('latitude', '');
+				expect($lat.val()).toEqual('');
+			});
+
+			it('Expects that when the model\'s longitude property is updated, the DOM is updated', function() {
+				testModel.set('longitude', '-100.0');
 				expect($lng.val()).toEqual('-100.0');
 
-				testModel.set('location', {
-					latitude : '43.0',
-					longitude : ''
-				});
-				expect($lat.val()).toEqual('43.0');
-				expect($lng.val()).toEqual('');
+				testModel.set('longitude', '-101.0');
+				expect($lng.val()).toEqual('-101.0');
 
-				testModel.set('location', {
-					latitude : '',
-					longitude : ''
-				});
-				expect($lat.val()).toEqual('');
+				testModel.set('longitude', '');
 				expect($lng.val()).toEqual('');
+			});
+
+			it('Expects that when then model\'s radius property is updated, the DOM is updated', function() {
+				testModel.set('radius', '4');
+				expect($radius.val()).toEqual('4');
+
+				testModel.set('radius', '5');
+				expect($radius.val()).toEqual('5');
+
+				testModel.set('radius', '');
+				expect($radius.val()).toEqual('');
 			});
 		});
 	});

--- a/src/test/js/views/NavViewSpec.js
+++ b/src/test/js/views/NavViewSpec.js
@@ -9,6 +9,8 @@ define([
 	'views/BaseView',
 	'views/NavView'
 ], function($, log, moment, Config, WorkflowStateModel, BaseView, NavView) {
+	"use strict";
+
 	describe('views/NavView', function() {
 		var testView;
 		var testModel;
@@ -16,7 +18,7 @@ define([
 		var $testDiv;
 		var fakeServer;
 
-		var projLocSel = '.nav-project-loc';
+		var projLocSel = '.nav-specify-aoi';
 		var chooseDataSel = '.nav-choose-data';
 		var processDataSel = '.nav-process-data';
 
@@ -33,7 +35,12 @@ define([
 				createDatasetModels : true
 			});
 
-			testModel.set('step', Config.PROJ_LOC_STEP);
+			testModel.set('step', Config.SPECIFY_AOI_STEP);
+			testModel.get('aoi').set({
+				latitude : '',
+				longitude : '',
+				radius : ''
+			});
 			mockRouter = jasmine.createSpyObj('mockRouter', ['navigate']);
 			log.setLevel('silent');
 		});
@@ -77,8 +84,12 @@ define([
 				expect($.fn.modal).toHaveBeenCalled();
 			});
 
-			it('Expects that if the workflow step is PROJ_LOC_STEP and no location is defined, the project location nav btn is active and the choose data and process data buttons are disabled', function() {
+			it('Expects that if the workflow step is SPECIFY_AOI_STEP and no location is defined, the project location nav btn is active and the choose data and process data buttons are disabled', function() {
+				testModel.set({
+					step : Config.SPECIFY_AOI_STEP
+				});
 				testView.render();
+
 				expect(testView.$(projLocSel + ' a').hasClass('active')).toBe(true);
 				expect(testView.$(chooseDataSel + ' a').hasClass('active')).toBe(false);
 				expect(testView.$(processDataSel + ' a').hasClass('active')).toBe(false);
@@ -87,10 +98,14 @@ define([
 				expect(testView.$(processDataSel).hasClass('disabled')).toBe(true);
 			});
 
-			it('Expects that if the workflow step is PROJ_LOC_STEP and location is defined, then the choose data btn is enabled', function() {
+			it('Expects that if the workflow step is SPECIFY_AOI_STEP and location and radius are defined, then the choose data btn is enabled', function() {
+				testModel.get('aoi').set({
+					latitude : 43.0,
+					longitude : -100.0,
+					radius : 2
+				});
 				testModel.set({
-					step : Config.PROJ_LOC_STEP,
-					location : {latitude : 43.0, longitude : -100.0}
+					step : Config.SPECIFY_AOI_STEP
 				});
 				testView.render();
 				expect(testView.$(projLocSel).hasClass('disabled')).toBe(false);
@@ -99,9 +114,13 @@ define([
 			});
 
 			it('Expects that if the workflow step is CHOOSE_DATA_FILTERS_STEP the choose data btn is active and the process data step is disabled', function() {
+				testModel.get('aoi').set({
+					latitude : 43.0,
+					longitude : -100.0,
+					radius : 2
+				});
 				testModel.set({
-					step : Config.CHOOSE_DATA_FILTERS_STEP,
-					location : {latitude : 43.0, longitude : -100.0}
+					step : Config.CHOOSE_DATA_FILTERS_STEP
 				});
 				testView.render();
 				expect(testView.$(projLocSel + ' a').hasClass('active')).toBe(false);
@@ -120,12 +139,16 @@ define([
 					model : testModel,
 					router : mockRouter
 				});
+				testModel.get('aoi').set({
+					latitude : 43.0,
+					longitude : -100.0,
+					radius : 2
+				});
 			});
 
 			it('Expects that clicking the choose data button, changes the step to CHOOSE_DATA_FILTERS_STEP', function() {
 				testModel.set({
-					step : Config.PROJ_LOC_STEP,
-					location : {latitude : 43.0, longitude : -100.0}
+					step : Config.SPECIFY_AOI_STEP
 				});
 				testView.render();
 				$(chooseDataSel + ' a').trigger('click');
@@ -135,8 +158,7 @@ define([
 
 			it('Expects that clicking the choose data button, only changes the step if the current step is not CHOOSE_DATA_FILTERS_STEP or CHOOSE_DATA_VARIABLES_STEP', function() {
 				testModel.set({
-					step : Config.CHOOSE_DATA_FILTERS_STEP,
-					location : {latitude : 43.0, longitude : -100.0}
+					step : Config.CHOOSE_DATA_FILTERS_STEP
 				});
 				testView.render();
 				$(chooseDataSel + ' a').trigger('click');
@@ -151,8 +173,7 @@ define([
 
 			it('Expects that clicking the project location button causes the warning modal to be shown', function() {
 				testModel.set({
-					step : Config.CHOOSE_DATA_FILTERS_STEP,
-					location : {latitude : 43.0, longitude : -100.0}
+					step : Config.CHOOSE_DATA_FILTERS_STEP
 				});
 				testView.render();
 				$.fn.modal.calls.reset();
@@ -164,8 +185,7 @@ define([
 			it('Expects that clicking the cancel button in the modal does nothing to the state of the workflow model', function() {
 				var currentWorkflowState;
 				testModel.set({
-					step : Config.CHOOSE_DATA_FILTERS_STEP,
-					location : {latitude : 43.0, longitude : -100.0}
+					step : Config.CHOOSE_DATA_FILTERS_STEP
 				});
 				currentWorkflowState = testModel.attributes;
 				testView.render();
@@ -175,18 +195,17 @@ define([
 				expect(testModel.attributes).toEqual(currentWorkflowState);
 			});
 
-			it('Expects that clicking the ok button sets the workflow step to PROJ_LOC_STEP', function() {
+			it('Expects that clicking the ok button sets the workflow step to SPECIFY_AOI_STEP', function() {
 				var currentWorkflowState;
 				testModel.set({
-					step : Config.CHOOSE_DATA_FILTERS_STEP,
-					location : {latitude : 43.0, longitude : -100.0}
+					step : Config.CHOOSE_DATA_FILTERS_STEP
 				});
 				currentWorkflowState = testModel.attributes;
 				testView.render();
 				$(projLocSel + ' a').trigger('click');
 				$('.nav-warning-modal .ok-button').trigger('click');
 
-				expect(testModel.get('step')).toEqual(Config.PROJ_LOC_STEP);
+				expect(testModel.get('step')).toEqual(Config.SPECIFY_AOI_STEP);
 			});
 		});
 
@@ -200,15 +219,15 @@ define([
 				testView.render();
 			});
 
-			it('Expects that if the location is defined when in the PROJ_LOC_STEP, the choose data btn becomes active', function() {
-				testModel.set('location', {latitude: 43.0, longitude : -100.0});
+			it('Expects that if the location  and radius are defined when in the SPECIFY_AOI_STEP, the choose data btn becomes active', function() {
+				testModel.get('aoi').set({latitude: 43.0, longitude : -100.0, radius : 4});
 				expect(testView.$(projLocSel).hasClass('disabled')).toBe(false);
 				expect(testView.$(chooseDataSel).hasClass('disabled')).toBe(false);
 				expect(testView.$(processDataSel).hasClass('disabled')).toBe(true);
 			});
 
 			it('Expects that if the step is changed to CHOOSE_DATA_FILTERS_STEP, the choose data btn is active', function() {
-				testModel.set('location', {latitude: 43.0, longitude : -100.0});
+				testModel.get('aoi').set({latitude: 43.0, longitude : -100.0, radius : 4});
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				expect(testView.$(projLocSel + ' a').hasClass('active')).toBe(false);
 				expect(testView.$(chooseDataSel + ' a').hasClass('active')).toBe(true);
@@ -218,37 +237,33 @@ define([
 				expect(testView.$(processDataSel).hasClass('disabled')).toBe(true);
 			});
 
-			it('Expects that if the step is changed to CHOOSE_DATA_FILTERS_STEP, then the router will navigate to the url with the lat and lon in it', function() {
+			it('Expects that if the step is changed to CHOOSE_DATA_FILTERS_STEP, then the router will navigate to the url with the lat/lon and radius in it', function() {
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
-				testModel.set({
-					location : {latitude: 42.0, longitude : -101.0},
-					radius : '',
-					datasets : []
-				});
-				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/42/lng/-101/dataset/']);
+				testModel.set('datasets', []);
+				testModel.get('aoi').set({latitude: 43.0, longitude : -100.0, radius : 4});
+
+				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/43/lng/-100/radius/4/dataset/']);
 			});
 
 			it('Expects that if the step is CHOOSE_DATA_FILTERS_STEP and the location becomes invalid that the url is not updated', function() {
+				var aoiModel = testModel.get('aoi');
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
-				testModel.set({
-					location : {latitude: 42.0, longitude : -101.0},
-					radius : '',
-					datasets : []
-				});
+				testModel.set('datasets', []);
+				aoiModel.set({latitude: 43.0, longitude : -100.0, radius : 4});
 
-				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/42/lng/-101/dataset/']);
+				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/43/lng/-100/radius/4/dataset/']);
 
 				mockRouter.navigate.calls.reset();
-				testModel.set('location', {latitude : '', longitude : -101.0});
+				aoiModel.set({latitude : '', longitude : -101.0});
 
 				expect(mockRouter.navigate).not.toHaveBeenCalled();
 			});
 
 			it('Expects that if the step is CHOOSE_DATA_FILTERS_STEP and radius, location, start/endDate, and datasets change the router will navigate to the appropriate url', function() {
-				testModel.set('location', {latitude: 43.0, longitude : -100.0});
+				var aoiModel = testModel.get('aoi');
+				aoiModel.set({latitude: 43.0, longitude : -100.0, radius : 2});
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				testModel.set({
-					radius : 2,
 					datasets : ['NWIS']
 				});
 				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/43/lng/-100/radius/2/dataset/NWIS']);
@@ -261,12 +276,12 @@ define([
 					endDate : moment('1Jan2010', DATE_FORMAT)
 				});
 				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/43/lng/-100/radius/2/startdate/1Jan2000/enddate/1Jan2010/dataset/NWIS/Precip']);
-				testModel.set('radius', 10);
+				aoiModel.set('radius', 10);
 				expect(mockRouter.navigate.calls.mostRecent().args).toEqual(['lat/43/lng/-100/radius/10/startdate/1Jan2000/enddate/1Jan2010/dataset/NWIS/Precip']);
 			});
 
 			it('Expects that if the step is CHOOSE_DATA_FILTERS_STEP and changed to CHOOSE_DATA_VARIABLES_STEP, the choose data btn remains active', function() {
-				testModel.set('location', {latitude: 43.0, longitude : -100.0});
+				testModel.get('aoi').set({latitude: 43.0, longitude : -100.0, radius : 4});
 				testModel.set('step', Config.CHOOSE_DATA_FILTERS_STEP);
 				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
 
@@ -280,7 +295,7 @@ define([
 
 			it('Expects that if the steop is CHOOSE_DATA_VARIABLES_STEP and the hasSelectedVariables is changed to true, the process data button in enabled', function() {
 				var processDataBtn = testView.$(processDataSel);
-				testModel.set('location', {latitude: 43.0, longitude : -100.0});
+				testModel.get('aoi').set({latitude: 43.0, longitude : -100.0, radius : 4});
 				testModel.set('step', Config.CHOOSE_DATA_VARIABLES_STEP);
 
 				expect(processDataBtn.hasClass('disabled')).toBe(true);


### PR DESCRIPTION
Implements the ability for the user to define their area of interest by drawing a rubber band box rather than specifying a location and radius.

Started by creating the module AOIModel. This is where the latitude, longitude and radius or aoiBox properties will be saved. The AOIModel defines functions to return information about what kind of AOI definition is being used as well as the bounding box defined. The WorkflowStateModel now defines an aoi property by default that is initialized to an empty AOIModel.

Changed the PROJ_LOC_STEP to SPECIFY_AOI_STEP. The first part of this workflow step is for the user to choose picking a location or drawing a box.  If the user picks drawing a box, the new view AOIViewBox is rendered rather than LocationView and in MapView, drawControls are added to the map rather than the project location marker.

In order to have the entire AOI defined in a single view, I moved the radius from Choose Data to the LocationView. The LocationView now only needs to have the AOIModel passed to it rather than the entire WorkflowStateModel.

The URL for the Choose Data step when the AOI box is used, will be #aoiBbox/south,west,north,south/...

