### PR TITLE
Refactor sites layer

### DIFF
--- a/src/main/webapp/js/views/BySiteLayerView.js
+++ b/src/main/webapp/js/views/BySiteLayerView.js
@@ -43,6 +43,10 @@ define([
 			return this;
 		},
 
+		/*
+		 * Model event handlers
+		 */
+		
 		updateSiteMarkers : function() {
 			var self = this;
 			var dateFilter = this.model.has('dataDateFilter') ? this.model.get('dataDateFilter') : undefined;

--- a/src/main/webapp/js/views/BySiteLayerView.js
+++ b/src/main/webapp/js/views/BySiteLayerView.js
@@ -1,0 +1,80 @@
+/* jslint browser: true */
+
+define([
+	'underscore',
+	'leaflet',
+	'backbone'
+], function(_, L, Backbone) {
+	"use strict";
+	/*
+	 * This view will be rendered at initialization. A call to render will be a no op.
+	 * @constructs
+	 * @param {Object} options
+	 *		@prop {Leaflet.Map} map
+	 *		@prop {WorkflowStateModel} model
+	 *		@prop {Jquery element} el - This is the parent div of the div which contains the map
+	 *		@prop {String} datasetKind - The kind of collection
+	 *		@prop {L.Icon} siteIcon - The icon to be used for the collection's sites
+	 *		@prop {Function} getTitle - To be used when hovering over a site
+	 *			@param {Backbone.Model - represents a model in collection} model
+	 *			@returns String
+	 */
+	var view = Backbone.View.extend({
+
+		initialize : function(options) {
+			Backbone.View.prototype.initialize.apply(this, arguments);
+			this.collection = this.model.get('datasetCollections')[options.datasetKind];
+			this.datasetKind = options.datasetKind;
+			this.map = options.map;
+			this.siteIcon = options.siteIcon;
+			this.getTitle = options.getTitle;
+
+			this.siteLayerGroup = L.layerGroup();
+			this.map.addLayer(this.siteLayerGroup);
+
+			this.listenTo(this.model, 'change:dataDateFilter', this.updateSiteMarkers);
+			this.listenTo(this.collection, 'reset', this.updateSiteMarkers);
+			this.updateSiteMarkers();
+		},
+
+		remove : function() {
+			this.siteLayerGroup.clearLayers();
+			this.map.removeLayer(this.siteLayerGroup);
+			return this;
+		},
+
+		updateSiteMarkers : function() {
+			var self = this;
+			var dateFilter = this.model.has('dataDateFilter') ? this.model.get('dataDateFilter') : undefined;
+			var filteredSiteModels = this.collection.getSiteModelsWithinDateFilter(dateFilter);
+			var selectedSite = (this.model.has('selectedSite')) ? this.model.get('selectedSite') : undefined;
+
+			if ((selectedSite) &&
+				(this.datasetKind === selectedSite.datasetKind) &&
+				!_.contains(filteredSiteModels, selectedSite.siteModel)) {
+				this.model.unset('selectedSite');
+			}
+
+			this.siteLayerGroup.clearLayers();
+			_.each(filteredSiteModels, function(siteModel) {
+				var latLng = L.latLng(siteModel.attributes.lat, siteModel.attributes.lon);
+				var marker = L.marker(latLng, {
+					icon : self.siteIcon,
+					title : self.getTitle(siteModel)
+				});
+
+				self.siteLayerGroup.addLayer(marker);
+				marker.on('click', function(ev) {
+					self.model.set('selectedSite', {
+						siteModel : siteModel,
+						datasetKind : self.datasetKind
+					});
+				});
+			});
+		}
+	});
+
+	return view;
+});
+
+

--- a/src/main/webapp/js/views/ByVariableTypeLayerView.js
+++ b/src/main/webapp/js/views/ByVariableTypeLayerView.js
@@ -1,0 +1,69 @@
+/* jslint browser: true */
+
+define([
+	'underscore',
+	'leaflet',
+	'backbone',
+	'utils/VariableDatasetMapping'
+], function(_, L, Backbone, variableDatasetMapping) {
+	"use strict";
+	/*
+	 * * This view will be rendered at initialization. A call to render will be a no op.
+	 * @constructs
+	 * @param {Object} options
+	 *		@prop {Leaflet.Map} map
+	 *		@prop {WorkflowStateModel} model
+	 *		@prop {Jquery element} el - This is the parent div of the div which contains the map
+	 *		@prop {String} datasetKind - The kind of collection
+	 *		@prop {L.Icon} siteIcon - The icon to be used for the collection's sites
+	 *		@prop {Function} getTitle - To be used when hovering over a site
+	 *			@param {Backbone.Model - represents a model in collection} model
+	 *			@returns String
+	 *
+	 */
+	var view = Backbone.View.extend({
+		initialize : function(options) {
+			Backbone.View.prototype.initialize.apply(this, arguments);
+			this.collection = this.model.get('datasetCollections')[options.datasetKind];
+			this.datasetKind = options.datasetKind;
+			this.map = options.map;
+			this.siteIcon = options.siteIcon;
+			this.getTitle = options.getTitle;
+
+			this.siteLayerGroup = L.layerGroup();
+			this.map.addLayer(this.siteLayerGroup);
+
+			this.listenTo(this.model, 'change:dataDateFilter', this.updateSiteMarkers);
+			this.listenTo(this.collection, 'reset', this.updateSiteMarkers);
+			this.listenTo(this.collection, 'dataset:updateVariablesInFilter', this.updateSiteMarkers);
+			this.updateSiteMarkers();
+		},
+
+		remove : function() {
+			this.siteLayerGroup.clearLayers();
+			this.map.removeLayer(this.siteLayerGroup);
+			return this;
+		},
+
+		updateSiteMarkers : function() {
+			var self = this;
+			var dateFilter = this.model.has('dataDateFilter') ? this.model.get('dataDateFilter') : undefined;
+			var varFilters = variableDatasetMapping.getFilters(this.datasetKind, this.model.get('variableKinds'));
+			var filteredSiteModels = this.collection.getSitesWithVariableInFilters(varFilters, dateFilter);
+
+			this.siteLayerGroup.clearLayers();
+			_.each(filteredSiteModels, function(siteModel) {
+				var latLng = L.latLng(siteModel.attributes.lat, siteModel.attributes.lon);
+				var marker = L.marker(latLng, {
+					icon : self.siteIcon,
+					title : self.getTitle(siteModel)
+				});
+
+				self.siteLayerGroup.addLayer(marker);
+			});
+		}
+	});
+
+	return view;
+});
+

--- a/src/main/webapp/js/views/DataDiscoveryView.js
+++ b/src/main/webapp/js/views/DataDiscoveryView.js
@@ -153,7 +153,6 @@ define([
 					if (!this.mapView) {
 						this.mapView = new MapView({
 							el : $utils.createDivInContainer(this.$(MAPVIEW_SELECTOR)),
-							mapDivId : 'map-div',
 							model : model
 						});
 						this.mapView.render();
@@ -308,7 +307,6 @@ define([
 			if (!this.mapView) {
 				this.mapView = new MapView({
 					el : $utils.createDivInContainer(this.$(MAPVIEW_SELECTOR)),
-					mapDivId : 'map-div',
 					model : this.model
 				});
 				this.mapView.render();

--- a/src/main/webapp/js/views/SitesLayerView.js
+++ b/src/main/webapp/js/views/SitesLayerView.js
@@ -142,11 +142,11 @@ define([
 							model : this.model,
 							el : this.el,
 							datasetKind : dataset,
-							filters : variableDatasetMapping.getFilters(dataset, this.model.get('variableKinds')),
 							siteIcon : siteIcons[dataset],
 							getTitle : getTitle[dataset]
 						});
 					}, this);
+					break;
 			}
 		},
 

--- a/src/main/webapp/js/views/SitesLayerView.js
+++ b/src/main/webapp/js/views/SitesLayerView.js
@@ -1,0 +1,193 @@
+/* jslint browser: true */
+
+define([
+	'underscore',
+	'backbone',
+	'leaflet',
+	'Config',
+	'utils/VariableDatasetMapping',
+	'utils/jqueryUtils',
+	'utils/LUtils',
+	'views/BySiteLayerView',
+	'views/ByVariableTypeLayerView',
+	'views/GLCFSDataView',
+	'views/ACISDataView',
+	'views/NWISDataView',
+	'views/PrecipDataView'
+], function(_, Backbone, L, Config, variableDatasetMapping, $utils, LUtils, BySiteLayerView, ByVariableTypeLayerView,
+			GLCFSDataView, ACISDataView, NWISDataView, PrecipDataView) {
+	"use strict";
+
+	var siteIcons = _.mapObject(Config.DATASET_ICON, function(value) {
+		return L.icon(value);
+	});
+
+	var getGLCFSTitle = function(model) {
+		return model.get('variables').at(0).get('y') + ':' + model.get('variables').at(0).get('x');
+	};
+
+	var getNWISTitle = function(model) {
+		return model.get('name');
+	};
+
+	var getPrecipTitle = function(model) {
+		return model.get('variables').at(0).get('y') + ':' + model.get('variables').at(0).get('x');
+	};
+
+	var getACISTitle = function(model) {
+		return model.get('name');
+	};
+
+	var getTitle = _.object([
+  		[Config.GLCFS_DATASET, getGLCFSTitle],
+		[Config.NWIS_DATASET, getNWISTitle],
+		[Config.PRECIP_DATASET, getPrecipTitle],
+		[Config.ACIS_DATASET, getACISTitle]
+	]);
+
+	var DataViews =_.object([
+  		[Config.GLCFS_DATASET, GLCFSDataView],
+		[Config.NWIS_DATASET, NWISDataView],
+		[Config.PRECIP_DATASET, PrecipDataView],
+		[Config.ACIS_DATASET, ACISDataView]
+	]);
+	var MAP_WIDTH_CLASS = 'col-md-6';
+	var DATA_VIEW_WIDTH_CLASS = 'col-md-6';
+
+	var MAP_DIV_SELECTOR = '#map-div';
+	var DATA_VIEW_CONTAINER = '.dataset-variable-container';
+
+	/*
+	 * This view will be rendered at initialization. A call to render will be a no op.
+	 * @constructs
+	 * Expects that the workflow step a
+	 * @param {Object} options
+	 *		@prop {Leaflet.Map} map
+	 *		@prop {Jquery element} el - This should be the parent div of the div that contains the map.
+	 *		@prop {WorkflowStateModel} model
+	 */
+	var view = Backbone.View.extend({
+
+		initialize : function(options) {
+			this.map = options.map;
+			this.circleMarker = L.circleMarker([0, 0], {
+				radius : 15
+			});
+			this.dataView = undefined;
+			this.siteLayers = _.object([
+				[Config.GLCFS_DATASET, undefined],
+				[Config.NWIS_DATASET, undefined],
+				[Config.PRECIP_DATASET, undefined],
+				[Config.ACIS_DATASET, undefined]
+			]);
+
+			if (this.model.has('datasetCollections')) {
+				this.createSiteLayers();
+			}
+			else {
+				this.listenToOnce(this.model, 'change:datasetCollections', this.createSiteLayers);
+			}
+		},
+
+		removeDataView : function() {
+			if (this.dataView) {
+				this.dataView.remove();
+				this.dataView = undefined;
+			}
+		},
+
+		remove : function() {
+			var $mapDiv = $(MAP_DIV_SELECTOR);
+			var $dataViewDiv = $(DATA_VIEW_CONTAINER);
+
+			this.removeDataView();
+			if ($mapDiv.hasClass(MAP_WIDTH_CLASS)) {
+				$mapDiv.removeClass(MAP_WIDTH_CLASS);
+				$dataViewDiv.removeClass(DATA_VIEW_WIDTH_CLASS);
+				this.map.invalidateSize();
+			}
+
+			if (this.map.hasLayer(this.circleMarker)) {
+				this.map.removeLayer(this.circleMarker);
+			}
+			_.each(this.siteLayers, function(siteLayer) {
+				siteLayer.remove();
+			});
+
+			this.model.unset('selectedSite');
+			return this;
+		},
+
+		createSiteLayers : function() {
+			switch(this.model.get('step')) {
+				case Config.CHOOSE_DATA_BY_SITE_FILTERS_STEP:
+				case Config.CHOOSE_DATA_BY_SITE_VARIABLES_STEP:
+					this.listenTo(this.model, 'change:selectedSite', this.updateSelectedSite);
+					_.each(Config.ALL_DATASETS, function(dataset) {
+						this.siteLayers[dataset] = new BySiteLayerView({
+							map : this.map,
+							model : this.model,
+							el : this.el,
+							datasetKind : dataset,
+							siteIcon : siteIcons[dataset],
+							getTitle : getTitle[dataset]
+						});
+					}, this);
+					break;
+
+				case Config.CHOOSE_DATA_BY_VARIABLES_STEP:
+					_.each(Config.ALL_DATASETS, function(dataset) {
+						this.siteLayers[dataset] = new ByVariableTypeLayerView({
+							map : this.map,
+							model : this.model,
+							el : this.el,
+							datasetKind : dataset,
+							filters : variableDatasetMapping.getFilters(dataset, this.model.get('variableKinds')),
+							siteIcon : siteIcons[dataset],
+							getTitle : getTitle[dataset]
+						});
+					}, this);
+			}
+		},
+
+		updateSelectedSite : function() {
+			var selectedSite = (this.model.has('selectedSite')) ? this.model.get('selectedSite') : undefined;
+			var projectBounds = LUtils.getLatLngBounds(this.model.get('aoi').getBoundingBox());
+			var projectLocation = projectBounds.getCenter();
+			var siteLatLng;
+			var $mapDiv = this.$(MAP_DIV_SELECTOR);
+			var $dataViewDiv = this.$(DATA_VIEW_CONTAINER);
+
+			this.removeDataView();
+			if (selectedSite) {
+				siteLatLng = L.latLng(selectedSite.siteModel.attributes.lat, selectedSite.siteModel.attributes.lon);
+				this.circleMarker.setLatLng(siteLatLng);
+				if (!this.map.hasLayer(this.circleMarker)) {
+					this.map.addLayer(this.circleMarker);
+				}
+				this.dataView = new DataViews[selectedSite.datasetKind]({
+					el : $utils.createDivInContainer($dataViewDiv),
+					distanceToProjectLocation : LUtils.milesBetween(projectLocation, siteLatLng).toFixed(3),
+					model : selectedSite.siteModel,
+					opened : true
+				});
+				this.dataView.render();
+				if (!$mapDiv.hasClass(MAP_WIDTH_CLASS)) {
+					$mapDiv.addClass(MAP_WIDTH_CLASS);
+					$dataViewDiv.addClass(DATA_VIEW_WIDTH_CLASS);
+					this.map.invalidateSize();
+				}
+			}
+			else if (this.map.hasLayer(this.circleMarker)) {
+				this.map.removeLayer(this.circleMarker);
+				$mapDiv.removeClass(MAP_WIDTH_CLASS);
+				$dataViewDiv.removeClass(DATA_VIEW_WIDTH_CLASS);
+				this.map.invalidateSize();
+			}
+		}
+	});
+
+	return view;
+});
+
+

--- a/src/main/webapp/js/views/SitesLayerView.js
+++ b/src/main/webapp/js/views/SitesLayerView.js
@@ -59,8 +59,9 @@ define([
 
 	/*
 	 * This view will be rendered at initialization. A call to render will be a no op.
+	 * The workflow step value determines whether the BySiteLayer or ByVariableTypeLayer view is created.
 	 * @constructs
-	 * Expects that the workflow step a
+	 *
 	 * @param {Object} options
 	 *		@prop {Leaflet.Map} map
 	 *		@prop {Jquery element} el - This should be the parent div of the div that contains the map.

--- a/src/test/js/views/BySiteLayerViewSpec.js
+++ b/src/test/js/views/BySiteLayerViewSpec.js
@@ -1,0 +1,164 @@
+/* jslint browser: true */
+/* global expect, spyOn */
+
+define([
+	'jquery',
+	'underscore',
+	'leaflet',
+	'backbone',
+	'moment',
+	'Config',
+	'models/BaseDatasetCollection',
+	'models/BaseVariableCollection',
+	'views/BySiteLayerView',
+	'hbs!hb_templates/mapOps'
+], function($, _, L, Backbone, moment, Config, BaseDatasetCollection, BaseVariableCollection, BySiteLayerView, mapOpsTemplate) {
+	"use strict";
+
+	describe('views/BySiteLayerView', function() {
+		var testView;
+		var $testDiv;
+		var testMap;
+		var testCollection, testModel;
+		var getATitle;
+
+		beforeEach(function() {
+			$('body').append('<div id="test-div"></div>');
+			$testDiv = $('#test-div');
+			$testDiv.html(mapOpsTemplate());
+			testMap = L.map('map-div', {
+				center : [41.0, -100.0],
+				zoom : 4
+			});
+
+			getATitle = function(model) {
+				return model.attributes.lat + ':' + model.attributes.lon;
+			};
+
+			testCollection = new BaseDatasetCollection([
+				{
+					lat : 43,
+					lon : -100,
+					variables : new BaseVariableCollection([{startDate : moment('2002-01-15', Config.DATE_FORMAT), endDate : moment('2005-09-01', Config.DATE_FORMAT)}])
+				},
+				{
+					lat : 42,
+					lon : -101,
+					variables : new BaseVariableCollection([{startDate : moment('2003-01-15', Config.DATE_FORMAT), endDate : moment('2015-09-01', Config.DATE_FORMAT)}])
+				}
+			]);
+			testModel = new Backbone.Model({
+				datasetCollections : {'ACIS' : testCollection}
+			});
+			testView = new BySiteLayerView({
+				map : testMap,
+				model : testModel,
+				el : $testDiv,
+				datasetKind : 'ACIS',
+				siteIcon : new L.Icon.Default(),
+				getTitle : getATitle
+			});
+		});
+
+		afterEach(function() {
+			testView.remove();
+			testMap.remove();
+			$testDiv.remove();
+		});
+
+		it('Expects that a layer is created for each site model', function() {
+			var markers;
+
+			expect(testView.siteLayerGroup).toBeDefined();
+			markers = testView.siteLayerGroup.getLayers();
+			expect(markers.length).toBe(2);
+			testCollection.each(function(model) {
+				expect(_.find(markers, function(marker) {
+					var latLng = marker.getLatLng();
+					return ((latLng.lat === model.attributes.lat) && (latLng.lng === model.attributes.lon));
+				})).toBeDefined();
+			});
+		});
+
+		describe('Tests for remove', function() {
+			it('Expects that the markers are cleared from the layer group and the layer group is removed from the map', function() {
+				spyOn(testMap, 'removeLayer').and.callThrough();
+				testView.remove();
+
+				expect(testView.siteLayerGroup.getLayers()).toEqual([]);
+				expect(testMap.removeLayer).toHaveBeenCalledWith(testView.siteLayerGroup);
+			});
+		});
+
+		describe('Tests for model event handlers', function() {
+			it('Expects that if the collection is reset, the siteLayerGroup contain markers representing the new collection', function() {
+				var markers;
+				testCollection.reset([
+					{
+						lat : 43,
+						lon : -100,
+						variables : new BaseVariableCollection([{startDate : moment('2002-01-15', Config.DATE_FORMAT), endDate : moment('2005-09-01', Config.DATE_FORMAT)}])
+					},
+					{
+						lat : 42,
+						lon : -101,
+						variables : new BaseVariableCollection([{startDate : moment('2003-01-15', Config.DATE_FORMAT), endDate : moment('2015-09-01', Config.DATE_FORMAT)}])
+					},
+					{
+						lat : 41,
+						lon : -98,
+						variables : new BaseVariableCollection([{startDate : moment('2008-01-01', Config.DATE_FORMAT), endDate : moment('2010-12-31', Config.DATE_FORMAT)}])
+					}
+				]);
+				markers = testView.siteLayerGroup.getLayers();
+
+				expect(markers.length).toBe(3);
+				testCollection.each(function(model) {
+					expect(_.find(markers, function(marker) {
+						var latLng = marker.getLatLng();
+						return ((latLng.lat === model.attributes.lat) && (latLng.lng === model.attributes.lon));
+					})).toBeDefined();
+				});
+			});
+
+			it('Expects that if the collection is reset to the empty collection, no site markers will be on the map', function() {
+				testCollection.reset([]);
+
+				expect(testView.siteLayerGroup.getLayers().length).toBe(0);
+			});
+
+			it('Expects that if the date filter is updated, the markers shown will be within the date filter', function() {
+				var markers;
+				testCollection.reset([
+					{
+						lat : 43,
+						lon : -100,
+						variables : new BaseVariableCollection([{startDate : moment('2002-01-15', Config.DATE_FORMAT), endDate : moment('2005-09-01', Config.DATE_FORMAT)}])
+					},
+					{
+						lat : 42,
+						lon : -101,
+						variables : new BaseVariableCollection([{startDate : moment('2003-01-15', Config.DATE_FORMAT), endDate : moment('2015-09-01', Config.DATE_FORMAT)}])
+					},
+					{
+						lat : 41,
+						lon : -98,
+						variables : new BaseVariableCollection([{startDate : moment('2008-01-01', Config.DATE_FORMAT), endDate : moment('2010-12-31', Config.DATE_FORMAT)}])
+					}
+				]);
+				testModel.set('dataDateFilter', {start : moment('2004-01-01', Config.DATE_FORMAT), end : moment('2006-01-01', Config.DATE_FORMAT)});
+				markers = testView.siteLayerGroup.getLayers();
+
+				expect(markers.length).toBe(2);
+				expect(_.find(markers, function(marker) {
+					var latLng = marker.getLatLng();
+					return ((latLng.lat === 43) && (latLng.lng === -100));
+				})).toBeDefined();
+				expect(_.find(markers, function(marker) {
+					var latLng = marker.getLatLng();
+					return ((latLng.lat === 42) && (latLng.lng === -101));
+				})).toBeDefined();
+			});
+		});
+	});
+});

--- a/src/test/js/views/BySiteLayerViewSpec.js
+++ b/src/test/js/views/BySiteLayerViewSpec.js
@@ -159,6 +159,13 @@ define([
 					return ((latLng.lat === 42) && (latLng.lng === -101));
 				})).toBeDefined();
 			});
+
+			it('Expects that if the selectedSite is set in the model, but the siteModel is not being displayed that the selectedSite is unset', function() {
+				testModel.set('selectedSite', {siteModel : testCollection.at(0), datasetKind : 'ACIS'});
+				testModel.set('dataDateFilter', {start : moment('2008-01-01', Config.DATE_FORMAT), end : moment('2010-01-01', Config.DATE_FORMAT)});
+
+				expect(testModel.has('selectedSite')).toBe(false);
+			});
 		});
 	});
 });

--- a/src/test/js/views/ByVariableTypeLayerViewSpec.js
+++ b/src/test/js/views/ByVariableTypeLayerViewSpec.js
@@ -1,0 +1,200 @@
+/* jslint browser: true */
+/* global expect, spyOn */
+
+define([
+	'jquery',
+	'underscore',
+	'leaflet',
+	'backbone',
+	'moment',
+	'Config',
+	'models/BaseDatasetCollection',
+	'models/BaseVariableCollection',
+	'views/ByVariableTypeLayerView',
+	'hbs!hb_templates/mapOps'
+], function($, _, L, Backbone, moment, Config, BaseDatasetCollection, BaseVariableCollection, ByVariableTypeLayerView, mapOpsTemplate) {
+	"use strict";
+
+	describe('views/ByVariableLayerView', function() {
+		var testView;
+		var $testDiv;
+		var testMap;
+		var testCollection, testModel;
+		var getATitle;
+
+		beforeEach(function() {
+			$('body').append('<div id="test-div"></div>');
+			$testDiv = $('#test-div');
+			$testDiv.html(mapOpsTemplate());
+			testMap = L.map('map-div', {
+				center : [41.0, -100.0],
+				zoom : 4
+			});
+
+			getATitle = function(model) {
+				return model.attributes.lat + ':' + model.attributes.lon;
+			};
+
+			testCollection = new BaseDatasetCollection([
+				{
+					lat : 43,
+					lon : -100,
+					variables : new BaseVariableCollection([{
+						code : 'pcpn',
+						startDate : moment('2002-01-15', Config.DATE_FORMAT),
+						endDate : moment('2005-09-01', Config.DATE_FORMAT)
+					}])
+				},
+				{
+					lat : 42,
+					lon : -101,
+					variables : new BaseVariableCollection([{
+						code : 'maxt',
+						startDate : moment('2003-01-15', Config.DATE_FORMAT),
+						endDate : moment('2015-09-01', Config.DATE_FORMAT)
+					}])
+				}
+			]);
+			testModel = new Backbone.Model({
+				datasetCollections : {'ACIS' : testCollection, NWIS : new BaseDatasetCollection([])},
+				variableKinds : ['precipitation']
+			});
+			testView = new ByVariableTypeLayerView({
+				map : testMap,
+				model : testModel,
+				el : $testDiv,
+				datasetKind : 'ACIS',
+				siteIcon : new L.Icon.Default(),
+				getTitle : getATitle
+			});
+		});
+
+		afterEach(function() {
+			testView.remove();
+			testMap.remove();
+			$testDiv.remove();
+		});
+
+		it('Expects that a layer is created for each site model that contains the variable filter', function() {
+			var markers;
+
+			expect(testView.siteLayerGroup).toBeDefined();
+			markers = testView.siteLayerGroup.getLayers();
+			expect(markers.length).toBe(1);
+			expect(_.find(markers, function(marker) {
+				var latLng = marker.getLatLng();
+				return ((latLng.lat === 43) && (latLng.lng === -100));
+			})).toBeDefined();
+		});
+
+		describe('Tests for remove', function() {
+			it('Expects that the markers are cleared from the layer group and the layer group is removed from the map', function() {
+				spyOn(testMap, 'removeLayer').and.callThrough();
+				testView.remove();
+
+				expect(testView.siteLayerGroup.getLayers()).toEqual([]);
+				expect(testMap.removeLayer).toHaveBeenCalledWith(testView.siteLayerGroup);
+			});
+		});
+
+		describe('Tests for model event handlers', function() {
+			it('Expects that if the collection is reset, the siteLayerGroup contain markers representing the new collection', function() {
+				var markers;
+				testCollection.reset([
+					{
+						lat : 43,
+						lon : -100,
+						variables : new BaseVariableCollection([{
+								code : 'pcpn',
+								startDate : moment('2002-01-15', Config.DATE_FORMAT),
+								endDate : moment('2005-09-01', Config.DATE_FORMAT)
+							}])
+					},
+					{
+						lat : 42,
+						lon : -101,
+						variables : new BaseVariableCollection([{
+								code : 'maxt',
+								startDate : moment('2003-01-15', Config.DATE_FORMAT),
+								endDate : moment('2015-09-01', Config.DATE_FORMAT)
+							}])
+					},
+					{
+						lat : 41,
+						lon : -98,
+						variables : new BaseVariableCollection([{
+								code : 'pcpn',
+								startDate : moment('2008-01-01', Config.DATE_FORMAT),
+								endDate : moment('2010-12-31', Config.DATE_FORMAT)}])
+					}
+				]);
+				markers = testView.siteLayerGroup.getLayers();
+
+				expect(markers.length).toBe(2);
+				expect(_.find(markers, function(marker) {
+					var latLng = marker.getLatLng();
+					return ((latLng.lat === 43) && (latLng.lng === -100));
+				})).toBeDefined();
+				expect(_.find(markers, function(marker) {
+					var latLng = marker.getLatLng();
+					return ((latLng.lat === 41) && (latLng.lng === -98));
+				})).toBeDefined();
+			});
+
+			it('Expects that if the collection is reset to the empty collection, no site markers will be on the map', function() {
+				testCollection.reset([]);
+
+				expect(testView.siteLayerGroup.getLayers().length).toBe(0);
+			});
+
+			it('Expects that if the date filter is updated, the markers shown will be within the date filter', function() {
+				var markers;
+				testCollection.reset([
+					{
+						lat : 43,
+						lon : -100,
+						variables : new BaseVariableCollection([{
+								code : 'pcpn',
+								startDate : moment('2002-01-15', Config.DATE_FORMAT),
+								endDate : moment('2005-09-01', Config.DATE_FORMAT)
+							}])
+					},
+					{
+						lat : 42,
+						lon : -101,
+						variables : new BaseVariableCollection([{
+								code : 'maxt',
+								startDate : moment('2003-01-15', Config.DATE_FORMAT),
+								endDate : moment('2015-09-01', Config.DATE_FORMAT)
+							}])
+					},
+					{
+						lat : 41,
+						lon : -98,
+						variables : new BaseVariableCollection([{
+								code : 'pcpn',
+								startDate : moment('2008-01-01', Config.DATE_FORMAT),
+								endDate : moment('2010-12-31', Config.DATE_FORMAT)}])
+					}
+				]);
+				testModel.set('dataDateFilter', {start : moment('2004-01-01', Config.DATE_FORMAT), end : moment('2006-01-01', Config.DATE_FORMAT)});
+				markers = testView.siteLayerGroup.getLayers();
+
+				expect(markers.length).toBe(1);
+				expect(_.find(markers, function(marker) {
+					var latLng = marker.getLatLng();
+					return ((latLng.lat === 43) && (latLng.lng === -100));
+				})).toBeDefined();
+			});
+
+			it('Expects if the variable kinds are updated, the expected markers are updated', function() {
+				var markers;
+				testModel.set('variableKinds', ['precipitation', 'maxTemperature']);
+				testCollection.trigger('dataset:updateVariablesInFilter');
+				markers = testView.siteLayerGroup.getLayers();
+
+				expect(markers.length).toBe(2);
+			});
+		});
+	});
+});

--- a/src/test/js/views/MapViewSpec.js
+++ b/src/test/js/views/MapViewSpec.js
@@ -18,7 +18,6 @@ define([
 		var testView;
 		var $testDiv;
 		var testModel;
-		var testSiteCollection, testPrecipCollection, testACISCollection, testGLCFSCollection;
 		var fakeServer;
 		var addLayerSpy, removeLayerSpy, addControlSpy, removeControlSpy, hasLayerSpy, removeMapSpy, fitBoundsSpy;
 
@@ -61,10 +60,6 @@ define([
 			});
 			testModel.set('step', Config.SPECIFY_AOI_STEP);
 			testModel.initializeDatasetCollections();
-			testSiteCollection = testModel.get('datasetCollections')[Config.NWIS_DATASET];
-			testPrecipCollection = testModel.get('datasetCollections')[Config.PRECIP_DATASET];
-			testACISCollection = testModel.get('datasetCollections')[Config.ACIS_DATASET];
-			testGLCFSCollection = testModel.get('datasetCollections')[Config.GLCFS_DATASET];
 
 			testView = new MapView({
 				el : '#test-div',

--- a/src/test/js/views/MapViewSpec.js
+++ b/src/test/js/views/MapViewSpec.js
@@ -46,8 +46,6 @@ define([
 				off : jasmine.createSpy('offSpy')
 			});
 			spyOn(L.control, 'layers').and.callThrough();
-			spyOn(L, 'marker').and.callThrough();
-			spyOn(L, 'layerGroup').and.callThrough();
 
 			spyOn(BaseView.prototype, 'initialize').and.callThrough();
 			spyOn(BaseView.prototype, 'remove').and.callThrough();

--- a/src/test/js/views/SitesLayerViewSpec.js
+++ b/src/test/js/views/SitesLayerViewSpec.js
@@ -1,0 +1,364 @@
+/* jslint browser */
+/* global expect, jasmine, spyOn */
+
+define([
+	'squire',
+	'underscore',
+	'jquery',
+	'leaflet',
+	'backbone',
+	'Config',
+	'models/BaseDatasetCollection',
+	'models/WorkflowStateModel',
+	'views/BaseView',
+	'hbs!hb_templates/mapOps'
+], function(Squire, _, $, L, Backbone, Config, BaseDatasetCollection, WorkflowStateModel, BaseView, mapOpsTemplate) {
+	"use strict";
+
+	fdescribe('views/SitesLayerViewSpec', function() {
+		var testView, SitesLayerView;
+		var $testDiv;
+		var testMap;
+		var initializeBySiteLayerViewSpy, removeBySiteLayerViewSpy;
+		var initializeByVariableLayerViewSpy, removeByVariableLayerViewSpy;
+		var setElGLCFSDataViewSpy, renderGLCFSDataViewSpy, removeGLCFSDataViewSpy;
+		var setElNWISDataViewSpy, renderNWISDataViewSpy, removeNWISDataViewSpy;
+		var setElPrecipDataViewSpy, renderPrecipDataViewSpy, removePrecipDataViewSpy;
+		var setElACISDataViewSpy, renderACISDataViewSpy, removeACISDataViewSpy;
+
+		var testModel;
+		var testGLCFSCollection, testNWISCollection, testPrecipCollection, testACISCollection;
+
+		var injector;
+
+		beforeEach(function(done) {
+			$('body').append('<div id="test-div"></div>');
+			$testDiv = $('#test-div');
+			$testDiv.html(mapOpsTemplate());
+			testMap = L.map('map-div', {
+				center : [41.0, -100.0],
+				zoom : 4
+			});
+
+			// Create spies for mocked views
+			initializeBySiteLayerViewSpy = jasmine.createSpy('renderBySiteLayerViewSpy');
+			removeBySiteLayerViewSpy = jasmine.createSpy('removeBySiteLayerViewSpy');
+
+			initializeByVariableLayerViewSpy = jasmine.createSpy('renderByVariableLayerViewSpy');
+			removeByVariableLayerViewSpy = jasmine.createSpy('removeByVariableLayerViewSpy');
+
+			setElGLCFSDataViewSpy = jasmine.createSpy('setElGLCFSDataViewSpy');
+			renderGLCFSDataViewSpy = jasmine.createSpy('renderGLCFSDataViewSpy');
+			removeGLCFSDataViewSpy = jasmine.createSpy('removeGLCFSDataViewSpy');
+
+			setElNWISDataViewSpy = jasmine.createSpy('setElNWISDataViewSpy');
+			renderNWISDataViewSpy = jasmine.createSpy('renderNWISDataViewSpy');
+			removeNWISDataViewSpy = jasmine.createSpy('removeNWISDataViewSpy');
+
+			setElPrecipDataViewSpy = jasmine.createSpy('setElPrecipDataViewSpy');
+			renderPrecipDataViewSpy = jasmine.createSpy('renderPrecipDataViewSpy');
+			removePrecipDataViewSpy = jasmine.createSpy('removePrecipDataViewSpy');
+
+			setElACISDataViewSpy = jasmine.createSpy('setElACISDataViewSpy');
+			renderACISDataViewSpy = jasmine.createSpy('renderACISDataViewSpy');
+			removeACISDataViewSpy = jasmine.createSpy('removeACISDataViewSpy');
+
+			injector = new Squire();
+			injector.mock('views/BySiteLayerView', Backbone.View.extend({
+				initialize : initializeBySiteLayerViewSpy,
+				remove : removeBySiteLayerViewSpy
+			}));
+			injector.mock('views/ByVariableTypeLayerView', Backbone.View.extend({
+				initialize : initializeByVariableLayerViewSpy,
+				remove : removeByVariableLayerViewSpy
+			}));
+			injector.mock('views/GLCFSDataView', BaseView.extend({
+				setElement : setElGLCFSDataViewSpy,
+				render : renderGLCFSDataViewSpy,
+				remove : removeGLCFSDataViewSpy
+			}));
+			injector.mock('views/NWISDataView', BaseView.extend({
+				setElement : setElNWISDataViewSpy,
+				render : renderNWISDataViewSpy,
+				remove : removeNWISDataViewSpy
+			}));
+			injector.mock('views/PrecipDataView', BaseView.extend({
+				setElement : setElPrecipDataViewSpy,
+				render : renderPrecipDataViewSpy,
+				remove : removePrecipDataViewSpy
+			}));
+			injector.mock('views/ACISDataView', BaseView.extend({
+				setElement : setElACISDataViewSpy,
+				render : renderACISDataViewSpy,
+				remove : removeACISDataViewSpy
+			}));
+
+			testModel = new WorkflowStateModel();
+			testGLCFSCollection = new BaseDatasetCollection();
+			testNWISCollection = new BaseDatasetCollection();
+			testPrecipCollection = new BaseDatasetCollection();
+			testACISCollection = new BaseDatasetCollection();
+
+			injector.require(['views/SitesLayerView'], function(View) {
+				SitesLayerView = View;
+
+				done();
+			});
+		});
+
+		afterEach(function() {
+			injector.remove();
+			if (testView) {
+				testView.remove();
+			}
+			testMap.remove();
+			$testDiv.remove();
+		});
+
+		it('Expects that the by site layers are created if the view is instantiated when the datasetCollections are defined and the workflow step is CHOOSE_DATA_BY_SITE', function() {
+			var viewArgs;
+			testModel.set('datasetCollections', _.object([
+				[Config.GLCFS_DATASET, testGLCFSCollection],
+				[Config.NWIS_DATASET, testNWISCollection],
+				[Config.Precip_DATASET, testPrecipCollection],
+				[Config.ACIS_DATASET, testACISCollection]
+			]));
+			testModel.set('step', Config.CHOOSE_DATA_BY_SITE_FILTERS_STEP);
+			testView = new SitesLayerView({
+				map : testMap,
+				el : $testDiv,
+				model : testModel
+			});
+			viewArgs = initializeBySiteLayerViewSpy.calls.allArgs();
+
+			expect(initializeBySiteLayerViewSpy.calls.count()).toBe(4);
+			_.each(Config.ALL_DATASETS, function(datasetKind) {
+				expect(_.find(viewArgs, function(arg) {
+					return arg.datasetKind = datasetKind;
+				})).toBeDefined();
+			});
+		});
+
+		it('Expects that the by variable layers are create if the view is instantiated when datasetCollections are defined and the workflow step is CHOOSE_DATA_BY_VARIABLES_STEP', function() {
+			var viewArgs;
+			testModel.set('datasetCollections', _.object([
+				[Config.GLCFS_DATASET, testGLCFSCollection],
+				[Config.NWIS_DATASET, testNWISCollection],
+				[Config.Precip_DATASET, testPrecipCollection],
+				[Config.ACIS_DATASET, testACISCollection]
+			]));
+			testModel.set('step', Config.CHOOSE_DATA_BY_VARIABLES_STEP);
+			testView = new SitesLayerView({
+				map : testMap,
+				el : $testDiv,
+				model : testModel
+			});
+			viewArgs = initializeByVariableLayerViewSpy.calls.allArgs();
+
+			expect(initializeByVariableLayerViewSpy.calls.count()).toBe(4);
+			_.each(Config.ALL_DATASETS, function(datasetKind) {
+				expect(_.find(viewArgs, function(arg) {
+					return arg.datasetKind = datasetKind;
+				})).toBeDefined();
+			});
+		});
+
+		describe('Tests that site layers are created if the datasetCollections are initialized after the view is created', function() {
+			beforeEach(function() {
+				testView = new SitesLayerView({
+					map : testMap,
+					el : $testDiv,
+					model : testModel
+				});
+			});
+
+			it('Expects that the by site layers are created after the datasetCollections are initialized when the workflow step is CHOOSE_DATA_BY_SITE', function() {
+				var viewArgs;
+				testModel.set('step', Config.CHOOSE_DATA_BY_SITE_FILTERS_STEP);
+				testModel.set('datasetCollections', _.object([
+					[Config.GLCFS_DATASET, testGLCFSCollection],
+					[Config.NWIS_DATASET, testNWISCollection],
+					[Config.Precip_DATASET, testPrecipCollection],
+					[Config.ACIS_DATASET, testACISCollection]
+				]));
+				viewArgs = initializeBySiteLayerViewSpy.calls.allArgs();
+
+				expect(initializeBySiteLayerViewSpy.calls.count()).toBe(4);
+				_.each(Config.ALL_DATASETS, function(datasetKind) {
+					expect(_.find(viewArgs, function(arg) {
+						return arg.datasetKind = datasetKind;
+					})).toBeDefined();
+				});
+			});
+
+			it('Expects that the by variable layers are created after the datasetCollections are initialized when the workflow step is CHOOSE_DATA_BY_VARIABLE', function() {
+				var viewArgs;
+				testModel.set('step', Config.CHOOSE_DATA_BY_VARIABLES_STEP);
+				testModel.set('datasetCollections', _.object([
+					[Config.GLCFS_DATASET, testGLCFSCollection],
+					[Config.NWIS_DATASET, testNWISCollection],
+					[Config.Precip_DATASET, testPrecipCollection],
+					[Config.ACIS_DATASET, testACISCollection]
+				]));
+				viewArgs = initializeByVariableLayerViewSpy.calls.allArgs();
+
+				expect(initializeByVariableLayerViewSpy.calls.count()).toBe(4);
+				_.each(Config.ALL_DATASETS, function(datasetKind) {
+					expect(_.find(viewArgs, function(arg) {
+						return arg.datasetKind = datasetKind;
+					})).toBeDefined();
+				});
+			});
+		});
+
+		describe('Tests for selectedSite model event handler when the workflow step is CHOOSE_DATA_BY_SITE', function() {
+			var testSite1Model, testSite2Model;
+			beforeEach(function() {
+				testSite1Model = new Backbone.Model({lat : '43', lon : '-100'});
+				testSite2Model = new Backbone.Model({lat : '42', lon : '-101'});
+				testACISCollection.add([testSite1Model]);
+				testNWISCollection.add([testSite2Model]);
+				testModel.set('step', Config.CHOOSE_DATA_BY_SITE_FILTERS_STEP);
+				testModel.get('aoi').set({latitude : '42.5', longitude : '-100.5', radius : 10});
+				testModel.set('datasetCollections', _.object([
+					[Config.GLCFS_DATASET, testGLCFSCollection],
+					[Config.NWIS_DATASET, testNWISCollection],
+					[Config.Precip_DATASET, testPrecipCollection],
+					[Config.ACIS_DATASET, testACISCollection]
+				]));
+				testView = new SitesLayerView({
+					map : testMap,
+					el : $testDiv,
+					model : testModel
+				});
+			});
+
+			it('Expects that if selectedSite is set to one of the models , the circle marker is added to the map at the expected location', function() {
+				var latLng;
+				spyOn(testMap, 'addLayer').and.callThrough();
+				testModel.set('selectedSite', {siteModel : testSite1Model, datasetKind : 'ACIS'});
+
+				expect(testMap.addLayer).toHaveBeenCalled();
+				latLng = testMap.addLayer.calls.argsFor(0)[0].getLatLng();
+				expect(latLng.lat).toEqual(43);
+				expect(latLng.lng).toEqual(-100);
+			});
+
+			it('Expects that if selectedSite is moved, the circle marker location is updated', function() {
+				var circleMarkerLayer, latLng;
+				spyOn(testMap, 'addLayer').and.callThrough();
+				testModel.set('selectedSite', {siteModel : testSite1Model, datasetKind : 'ACIS'});
+				circleMarkerLayer = testMap.addLayer.calls.argsFor(0)[0];
+				testModel.set('selectedSite', {siteModel : testSite2Model, datasetKind : 'NWIS'});
+				latLng = circleMarkerLayer.getLatLng();
+
+				expect(latLng.lat).toEqual(42);
+				expect(latLng.lng).toEqual(-101);
+			});
+
+			it('Expects that if the selectedSite is set and then unset the circle marker is removed from the map', function() {
+				var circleMarkerLayer;
+				spyOn(testMap, 'addLayer').and.callThrough();
+				spyOn(testMap, 'removeLayer').and.callThrough();
+				testModel.set('selectedSite', {siteModel : testSite1Model, datasetKind : 'ACIS'});
+				circleMarkerLayer = testMap.addLayer.calls.argsFor(0)[0];
+				testModel.unset('selectedSite');
+
+				expect(testMap.removeLayer).toHaveBeenCalled();
+				expect(testMap.removeLayer.calls.argsFor(0)[0]).toBe(circleMarkerLayer);
+			});
+
+			it('Expects that if the selectedSite is set to one of the models, the expected DataView is created and rendered', function() {
+				testModel.set('selectedSite', {siteModel : testSite1Model, datasetKind : 'ACIS'});
+
+				expect(renderACISDataViewSpy).toHaveBeenCalled();
+			});
+
+			it('Expects that if the selectedSite is changed, the current data view is removed and the expected one created and rendered', function() {
+				testModel.set('selectedSite', {siteModel : testSite1Model, datasetKind : 'ACIS'});
+				testModel.set('selectedSite', {siteModel : testSite2Model, datasetKind : 'NWIS'});
+
+				expect(removeACISDataViewSpy).toHaveBeenCalled();
+				expect(renderNWISDataViewSpy).toHaveBeenCalled();
+			});
+
+			it('Expects that if the selectedSite is set and then unset, the dataView is removed', function() {
+				testModel.set('selectedSite', {siteModel : testSite1Model, datasetKind : 'ACIS'});
+				testModel.unset('selectedSite');
+
+				expect(removeACISDataViewSpy).toHaveBeenCalled();
+			});
+		});
+
+		describe('Tests for remove when workflow step is choose by site', function() {
+			var testSite1Model, testSite2Model;
+			beforeEach(function() {
+				testSite1Model = new Backbone.Model({lat : '43', lon : '-100'});
+				testSite2Model = new Backbone.Model({lat : '42', lon : '-101'});
+				testACISCollection.add([testSite1Model]);
+				testNWISCollection.add([testSite2Model]);
+				testModel.set('step', Config.CHOOSE_DATA_BY_SITE_FILTERS_STEP);
+				testModel.get('aoi').set({latitude : '42.5', longitude : '-100.5', radius : 10});
+				testModel.set('datasetCollections', _.object([
+					[Config.GLCFS_DATASET, testGLCFSCollection],
+					[Config.NWIS_DATASET, testNWISCollection],
+					[Config.Precip_DATASET, testPrecipCollection],
+					[Config.ACIS_DATASET, testACISCollection]
+				]));
+				testView = new SitesLayerView({
+					map : testMap,
+					el : $testDiv,
+					model : testModel
+				});
+			});
+			it('Expects that if the step is CHOOSE_DATA_BY_SITE and an selectedSite is set, the views created are removed', function() {
+					testModel.set('selectedSite', {siteModel : testSite1Model, datasetKind : 'ACIS'});
+					testView.remove();
+
+					expect(removeACISDataViewSpy).toHaveBeenCalled();
+					expect(removeBySiteLayerViewSpy.calls.count()).toBe(4);
+			});
+			it('Expects that if the step is CHOOSE_DATA_BY_SITE and an selectedSite is set, the selectedSite is unset', function() {
+				testModel.set('selectedSite', {siteModel : testSite1Model, datasetKind : 'ACIS'});
+				testView.remove();
+
+				expect(testModel.has('selectedSite')).toBe(false);
+			});
+			it('Expects that if the step is CHOOSE_DATA_BY_SITE and an selectedSite is set, the circleMarker is removed from the map', function() {
+				var circleMarkerLayer;
+				spyOn(testMap, 'addLayer').and.callThrough();
+				spyOn(testMap, 'removeLayer').and.callThrough();
+				testModel.set('selectedSite', {siteModel : testSite1Model, datasetKind : 'ACIS'});
+				circleMarkerLayer = testMap.addLayer.calls.argsFor(0)[0];
+				testView.remove();
+
+				expect(testMap.removeLayer).toHaveBeenCalled();
+				expect(testMap.removeLayer.calls.argsFor(0)[0]).toBe(circleMarkerLayer);
+			});
+		});
+
+		describe('Tests for remove when workflow step is choose by variable type', function() {
+			beforeEach(function() {
+				testModel.set('step', Config.CHOOSE_DATA_BY_VARIABLES_STEP);
+				testModel.get('aoi').set({latitude : '42.5', longitude : '-100.5', radius : 10});
+				testModel.set('datasetCollections', _.object([
+					[Config.GLCFS_DATASET, testGLCFSCollection],
+					[Config.NWIS_DATASET, testNWISCollection],
+					[Config.Precip_DATASET, testPrecipCollection],
+					[Config.ACIS_DATASET, testACISCollection]
+				]));
+				testView = new SitesLayerView({
+					map : testMap,
+					el : $testDiv,
+					model : testModel
+				});
+			});
+
+			it('Expects that if the view is remove, the expected ByVariableLayerViews are removed', function() {
+				testView.remove();
+
+				expect(removeByVariableLayerViewSpy.calls.count()).toBe(4);
+			});
+		});
+	});
+});

--- a/src/test/js/views/SitesLayerViewSpec.js
+++ b/src/test/js/views/SitesLayerViewSpec.js
@@ -15,7 +15,7 @@ define([
 ], function(Squire, _, $, L, Backbone, Config, BaseDatasetCollection, WorkflowStateModel, BaseView, mapOpsTemplate) {
 	"use strict";
 
-	fdescribe('views/SitesLayerViewSpec', function() {
+	describe('views/SitesLayerViewSpec', function() {
 		var testView, SitesLayerView;
 		var $testDiv;
 		var testMap;
@@ -64,6 +64,7 @@ define([
 			removeACISDataViewSpy = jasmine.createSpy('removeACISDataViewSpy');
 
 			injector = new Squire();
+			injector.mock('leaflet', L);
 			injector.mock('views/BySiteLayerView', Backbone.View.extend({
 				initialize : initializeBySiteLayerViewSpy,
 				remove : removeBySiteLayerViewSpy


### PR DESCRIPTION
This is the first part of ENDDAT-248. The goal of this refactor was to put the site layer creation and management into its own view and to separate the site layer management into a module for the BySite workflow and another for the ByVariableType workflow.

Still need to add the new functionality for the ByVariableType workflow.